### PR TITLE
CLDC-2596: Add bulk upload bucket

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -60,28 +60,28 @@ module "cds_export" {
 module "application" {
   source = "../modules/application"
 
-  prefix                          = local.prefix
-  app_host                        = ""
-  application_port                = local.application_port
+  prefix                               = local.prefix
+  app_host                             = ""
+  application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
   bulk_upload_bucket_details           = module.bulk_upload.details
-  database_connection_string_arn  = module.database.rds_connection_string_arn
-  database_data_access_policy_arn = module.database.rds_data_access_policy_arn
-  database_port                   = local.database_port
-  db_security_group_id            = module.database.rds_security_group_id
-  ecr_repository_url              = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
-  ecs_task_cpu                    = 512
-  ecs_task_desired_count          = 2
-  ecs_task_memory                 = 1024
-  export_bucket_access_policy_arn = module.cds_export.read_write_policy_arn
-  export_bucket_details           = module.cds_export.details
-  load_balancer_target_group_arn  = module.front_door.load_balancer_target_group_arn
-  private_subnet_ids              = module.networking.private_subnet_ids
-  redis_connection_string         = module.redis.redis_connection_string
-  rails_env                       = "development"
-  redis_port                      = local.redis_port
-  redis_security_group_id         = module.redis.redis_security_group_id
-  vpc_id                          = module.networking.vpc_id
+  database_connection_string_arn       = module.database.rds_connection_string_arn
+  database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
+  database_port                        = local.database_port
+  db_security_group_id                 = module.database.rds_security_group_id
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecs_task_cpu                         = 512
+  ecs_task_desired_count               = 2
+  ecs_task_memory                      = 1024
+  export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
+  export_bucket_details                = module.cds_export.details
+  load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
+  private_subnet_ids                   = module.networking.private_subnet_ids
+  redis_connection_string              = module.redis.redis_connection_string
+  rails_env                            = "development"
+  redis_port                           = local.redis_port
+  redis_security_group_id              = module.redis.redis_security_group_id
+  vpc_id                               = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -45,6 +45,12 @@ module "database" {
   vpc_id                = module.networking.vpc_id
 }
 
+module "bulk_upload" {
+  source = "../modules/bulk_upload"
+
+  prefix = local.prefix
+}
+
 module "cds_export" {
   source = "../modules/cds_export"
 
@@ -57,6 +63,8 @@ module "application" {
   prefix                          = local.prefix
   app_host                        = ""
   application_port                = local.application_port
+  bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
+  bulk_upload_bucket_details           = module.bulk_upload.details
   database_connection_string_arn  = module.database.rds_connection_string_arn
   database_data_access_policy_arn = module.database.rds_data_access_policy_arn
   database_port                   = local.database_port

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 locals {
-  export_bucket_key = "export-bucket"
+  export_bucket_key      = "export-bucket"
   bulk_upload_bucket_key = "bulk-upload-bucket"
   s3_config = [
     {

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -6,11 +6,16 @@ resource "aws_ecs_cluster" "main" {
 
 locals {
   export_bucket_key = "export-bucket"
+  bulk_upload_bucket_key = "bulk-upload-bucket"
   s3_config = [
+    {
+      instance_name : local.bulk_upload_bucket_key,
+      credentials : var.bulk_upload_bucket_details
+    },
     {
       instance_name : local.export_bucket_key,
       credentials : var.export_bucket_details
-    }
+    },
   ]
 }
 
@@ -31,7 +36,7 @@ resource "aws_ecs_task_definition" "main" {
       environment = [
         { Name = "API_USER", Value = "dluhc-user" },
         { Name = "APP_HOST", Value = var.app_host },
-        { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = "" },
+        { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
         { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
         { Name = "IMPORT_PAAS_INSTANCE", Value = "" },
         { Name = "RAILS_ENV", Value = var.rails_env },

--- a/terraform/modules/application/roles.tf
+++ b/terraform/modules/application/roles.tf
@@ -74,6 +74,11 @@ resource "aws_iam_role_policy_attachment" "task_allow_ecs_exec" {
   policy_arn = aws_iam_policy.allow_ecs_exec.arn
 }
 
+resource "aws_iam_role_policy_attachment" "task_bulk_upload_bucket_access" {
+  role       = aws_iam_role.task.name
+  policy_arn = var.bulk_upload_bucket_access_policy_arn
+}
+
 resource "aws_iam_role_policy_attachment" "task_export_bucket_access" {
   role       = aws_iam_role.task.name
   policy_arn = var.export_bucket_access_policy_arn

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -8,6 +8,19 @@ variable "application_port" {
   description = "The network port the application runs on"
 }
 
+variable "bulk_upload_bucket_access_policy_arn" {
+  type        = string
+  description = "The arn of the policy allowing access to the bulk upload bucket"
+}
+
+variable "bulk_upload_bucket_details" {
+  type = object({
+    aws_region  = string
+    bucket_name = string
+  })
+  description = "Details block for bulk upload bucket"
+}
+
 variable "database_connection_string_arn" {
   type        = string
   description = "The arn of the datbase connection string in parameter store"

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -1,0 +1,62 @@
+#tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
+#tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
+#tfsec:ignore:aws-s3-enable-bucket-logging: TODO CLDC-2728
+#tfsec:ignore:aws-s3-enable-versioning: Not important, each upload creates a new file with a different name (a random UUID)
+resource "aws_s3_bucket" "this" {
+  #checkov:skip=CKV2_AWS_62: no need for event notifications
+  #checkov:skip=CKV_AWS_18: access logging - TODO CLDC-2728
+  #checkov:skip=CKV_AWS_145: default encryption is fine
+  #checkov:skip=CKV_AWS_144: cross region replication is overkill when this is only for data transfer
+  #checkov:skip=CKV_AWS_21: versioning not important, each upload creates a new file with a different name (a random UUID)
+  bucket = "${var.prefix}-bulk-upload-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id = "expire-old-data"
+
+    filter {}
+
+    expiration {
+      days = 30
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
+    status = "Enabled"
+  }
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards: require access to all objects in bucket
+data "aws_iam_policy_document" "read_write" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.this.arn]
+    effect    = "Allow"
+  }
+
+  statement {
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "read_write" {
+  name        = "${var.prefix}-bulk-upload-bucket-read-write"
+  description = "Policy that allows read/write access to the bulk upload bucket"
+  policy      = data.aws_iam_policy_document.read_write.json
+}

--- a/terraform/modules/bulk_upload/main.tf
+++ b/terraform/modules/bulk_upload/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~>1.5.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}

--- a/terraform/modules/bulk_upload/outputs.tf
+++ b/terraform/modules/bulk_upload/outputs.tf
@@ -1,0 +1,9 @@
+output "details" {
+  value       = { aws_region : aws_s3_bucket.this.region, bucket_name : aws_s3_bucket.this.id }
+  description = "Details block for this bucket for the application to use to connect"
+}
+
+output "read_write_policy_arn" {
+  value       = aws_iam_policy.read_write.arn
+  description = "Arn for policy allowing read/write access to objects in this bucket"
+}

--- a/terraform/modules/bulk_upload/variables.tf
+++ b/terraform/modules/bulk_upload/variables.tf
@@ -1,0 +1,4 @@
+variable "prefix" {
+  type        = string
+  description = "The prefix to be prepended to resource names."
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -45,6 +45,12 @@ module "database" {
   vpc_id                = module.networking.vpc_id
 }
 
+module "bulk_upload" {
+  source = "../modules/bulk_upload"
+
+  prefix = local.prefix
+}
+
 module "cds_export" {
   source = "../modules/cds_export"
 
@@ -57,6 +63,8 @@ module "application" {
   prefix                          = local.prefix
   app_host                        = ""
   application_port                = local.application_port
+  bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
+  bulk_upload_bucket_details           = module.bulk_upload.details
   database_connection_string_arn  = module.database.rds_connection_string_arn
   database_data_access_policy_arn = module.database.rds_data_access_policy_arn
   database_port                   = local.database_port

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -60,28 +60,28 @@ module "cds_export" {
 module "application" {
   source = "../modules/application"
 
-  prefix                          = local.prefix
-  app_host                        = ""
-  application_port                = local.application_port
+  prefix                               = local.prefix
+  app_host                             = ""
+  application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
   bulk_upload_bucket_details           = module.bulk_upload.details
-  database_connection_string_arn  = module.database.rds_connection_string_arn
-  database_data_access_policy_arn = module.database.rds_data_access_policy_arn
-  database_port                   = local.database_port
-  db_security_group_id            = module.database.rds_security_group_id
-  ecr_repository_url              = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
-  ecs_task_cpu                    = 512
-  ecs_task_desired_count          = 2
-  ecs_task_memory                 = 1024
-  export_bucket_access_policy_arn = module.cds_export.read_write_policy_arn
-  export_bucket_details           = module.cds_export.details
-  load_balancer_target_group_arn  = module.front_door.load_balancer_target_group_arn
-  private_subnet_ids              = module.networking.private_subnet_ids
-  redis_connection_string         = module.redis.redis_connection_string
-  rails_env                       = "production"
-  redis_port                      = local.redis_port
-  redis_security_group_id         = module.redis.redis_security_group_id
-  vpc_id                          = module.networking.vpc_id
+  database_connection_string_arn       = module.database.rds_connection_string_arn
+  database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
+  database_port                        = local.database_port
+  db_security_group_id                 = module.database.rds_security_group_id
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecs_task_cpu                         = 512
+  ecs_task_desired_count               = 2
+  ecs_task_memory                      = 1024
+  export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
+  export_bucket_details                = module.cds_export.details
+  load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
+  private_subnet_ids                   = module.networking.private_subnet_ids
+  redis_connection_string              = module.redis.redis_connection_string
+  rails_env                            = "production"
+  redis_port                           = local.redis_port
+  redis_security_group_id              = module.redis.redis_security_group_id
+  vpc_id                               = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -45,6 +45,12 @@ module "database" {
   vpc_id                = module.networking.vpc_id
 }
 
+module "bulk_upload" {
+  source = "../modules/bulk_upload"
+
+  prefix = local.prefix
+}
+
 module "cds_export" {
   source = "../modules/cds_export"
 
@@ -57,6 +63,8 @@ module "application" {
   prefix                          = local.prefix
   app_host                        = ""
   application_port                = local.application_port
+  bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
+  bulk_upload_bucket_details           = module.bulk_upload.details
   database_connection_string_arn  = module.database.rds_connection_string_arn
   database_data_access_policy_arn = module.database.rds_data_access_policy_arn
   database_port                   = local.database_port

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -60,28 +60,28 @@ module "cds_export" {
 module "application" {
   source = "../modules/application"
 
-  prefix                          = local.prefix
-  app_host                        = ""
-  application_port                = local.application_port
+  prefix                               = local.prefix
+  app_host                             = ""
+  application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
   bulk_upload_bucket_details           = module.bulk_upload.details
-  database_connection_string_arn  = module.database.rds_connection_string_arn
-  database_data_access_policy_arn = module.database.rds_data_access_policy_arn
-  database_port                   = local.database_port
-  db_security_group_id            = module.database.rds_security_group_id
-  ecr_repository_url              = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
-  ecs_task_cpu                    = 512
-  ecs_task_desired_count          = 2
-  ecs_task_memory                 = 1024
-  export_bucket_access_policy_arn = module.cds_export.read_write_policy_arn
-  export_bucket_details           = module.cds_export.details
-  load_balancer_target_group_arn  = module.front_door.load_balancer_target_group_arn
-  private_subnet_ids              = module.networking.private_subnet_ids
-  redis_connection_string         = module.redis.redis_connection_string
-  rails_env                       = "staging"
-  redis_port                      = local.redis_port
-  redis_security_group_id         = module.redis.redis_security_group_id
-  vpc_id                          = module.networking.vpc_id
+  database_connection_string_arn       = module.database.rds_connection_string_arn
+  database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
+  database_port                        = local.database_port
+  db_security_group_id                 = module.database.rds_security_group_id
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecs_task_cpu                         = 512
+  ecs_task_desired_count               = 2
+  ecs_task_memory                      = 1024
+  export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
+  export_bucket_details                = module.cds_export.details
+  load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
+  private_subnet_ids                   = module.networking.private_subnet_ids
+  redis_connection_string              = module.redis.redis_connection_string
+  rails_env                            = "staging"
+  redis_port                           = local.redis_port
+  redis_security_group_id              = module.redis.redis_security_group_id
+  vpc_id                               = module.networking.vpc_id
 }
 
 module "front_door" {


### PR DESCRIPTION
This PR is almost identical to https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/10. The differences are:
- different names (`bulk_upload` rather than `export`)
- slightly updated checkov/tfsec comments