### PR TITLE
CLDC-2710: Restrict ECS/LB security group ingress/egress rules

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -88,11 +88,11 @@ module "application" {
 module "front_door" {
   source = "../modules/front_door"
 
-  prefix            = local.prefix
-  application_port  = local.application_port
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  public_subnet_ids = module.networking.public_subnet_ids
-  vpc_id            = module.networking.vpc_id
+  prefix                = local.prefix
+  application_port      = local.application_port
+  ecs_security_group_id = module.application.ecs_security_group_id
+  public_subnet_ids     = module.networking.public_subnet_ids
+  vpc_id                = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -75,6 +75,7 @@ module "application" {
   ecs_task_memory                      = 1024
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
   export_bucket_details                = module.cds_export.details
+  load_balancer_security_group_id      = module.front_door.load_balancer_security_group_id
   load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
   private_subnet_ids                   = module.networking.private_subnet_ids
   redis_connection_string              = module.redis.redis_connection_string

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -90,6 +90,7 @@ module "front_door" {
 
   prefix            = local.prefix
   application_port  = local.application_port
+  ecs_security_group_id   = module.application.ecs_security_group_id
   public_subnet_ids = module.networking.public_subnet_ids
   vpc_id            = module.networking.vpc_id
 }

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -9,12 +9,12 @@ resource "aws_security_group" "ecs" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ecs_ingress" {
-  description       = "Allow ingress on port ${var.application_port} from the load balancer only"
-  ip_protocol       = "tcp"
-  from_port         = var.application_port
-  to_port           = var.application_port
+  description                  = "Allow ingress on port ${var.application_port} from the load balancer only"
+  ip_protocol                  = "tcp"
+  from_port                    = var.application_port
+  to_port                      = var.application_port
   referenced_security_group_id = var.load_balancer_security_group_id
-  security_group_id = aws_security_group.ecs.id
+  security_group_id            = aws_security_group.ecs.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "ecs_db_egress" {

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -9,11 +9,11 @@ resource "aws_security_group" "ecs" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ecs_ingress" {
-  description       = "Allow ingress on port ${var.application_port} from any IP address"
-  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow ingress on port ${var.application_port} from the load balancer only"
   ip_protocol       = "tcp"
   from_port         = var.application_port
   to_port           = var.application_port
+  referenced_security_group_id = var.load_balancer_security_group_id
   security_group_id = aws_security_group.ecs.id
 }
 

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -74,6 +74,11 @@ variable "export_bucket_details" {
   description = "Details block for export bucket"
 }
 
+variable "load_balancer_security_group_id" {
+  type        = string
+  description = "The id of the load balancer security group"
+}
+
 variable "load_balancer_target_group_arn" {
   type        = string
   description = "The arn of the load balancer target group to be associated with the ecs"

--- a/terraform/modules/front_door/outputs.tf
+++ b/terraform/modules/front_door/outputs.tf
@@ -1,3 +1,8 @@
+output "load_balancer_security_group_id" {
+  value       = aws_security_group.load_balancer.id
+  description = "The id of the load balancer security group"
+}
+
 output "load_balancer_target_group_arn" {
   value       = aws_lb_target_group.main.arn
   description = "The arn of the load balancer target group to be associated with the ecs"

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -28,10 +28,10 @@ resource "aws_vpc_security_group_ingress_rule" "load_balancer_https_ingress" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "load_balancer_container_egress" {
-  description       = "Allow egress to port ${var.application_port} on the ecs security group "
-  ip_protocol       = "tcp"
-  from_port         = var.application_port
-  to_port           = var.application_port
+  description                  = "Allow egress to port ${var.application_port} on the ecs security group "
+  ip_protocol                  = "tcp"
+  from_port                    = var.application_port
+  to_port                      = var.application_port
   referenced_security_group_id = var.ecs_security_group_id
-  security_group_id = aws_security_group.load_balancer.id
+  security_group_id            = aws_security_group.load_balancer.id
 }

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -28,10 +28,10 @@ resource "aws_vpc_security_group_ingress_rule" "load_balancer_https_ingress" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "load_balancer_container_egress" {
-  description       = "Allow egress to port ${var.application_port} from all IP addresses"
-  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow egress to port ${var.application_port} on the ecs security group "
   ip_protocol       = "tcp"
   from_port         = var.application_port
   to_port           = var.application_port
+  referenced_security_group_id = var.ecs_security_group_id
   security_group_id = aws_security_group.load_balancer.id
 }

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -3,6 +3,11 @@ variable "application_port" {
   description = "The network port the application runs on"
 }
 
+variable "ecs_security_group_id" {
+  type        = string
+  description = "The id of the ecs security group"
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to be prepended to resource names."

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -88,11 +88,11 @@ module "application" {
 module "front_door" {
   source = "../modules/front_door"
 
-  prefix            = local.prefix
-  application_port  = local.application_port
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  public_subnet_ids = module.networking.public_subnet_ids
-  vpc_id            = module.networking.vpc_id
+  prefix                = local.prefix
+  application_port      = local.application_port
+  ecs_security_group_id = module.application.ecs_security_group_id
+  public_subnet_ids     = module.networking.public_subnet_ids
+  vpc_id                = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -75,6 +75,7 @@ module "application" {
   ecs_task_memory                      = 1024
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
   export_bucket_details                = module.cds_export.details
+  load_balancer_security_group_id      = module.front_door.load_balancer_security_group_id
   load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
   private_subnet_ids                   = module.networking.private_subnet_ids
   redis_connection_string              = module.redis.redis_connection_string

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -90,6 +90,7 @@ module "front_door" {
 
   prefix            = local.prefix
   application_port  = local.application_port
+  ecs_security_group_id   = module.application.ecs_security_group_id
   public_subnet_ids = module.networking.public_subnet_ids
   vpc_id            = module.networking.vpc_id
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -88,11 +88,11 @@ module "application" {
 module "front_door" {
   source = "../modules/front_door"
 
-  prefix            = local.prefix
-  application_port  = local.application_port
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  public_subnet_ids = module.networking.public_subnet_ids
-  vpc_id            = module.networking.vpc_id
+  prefix                = local.prefix
+  application_port      = local.application_port
+  ecs_security_group_id = module.application.ecs_security_group_id
+  public_subnet_ids     = module.networking.public_subnet_ids
+  vpc_id                = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -75,6 +75,7 @@ module "application" {
   ecs_task_memory                      = 1024
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
   export_bucket_details                = module.cds_export.details
+  load_balancer_security_group_id      = module.front_door.load_balancer_security_group_id
   load_balancer_target_group_arn       = module.front_door.load_balancer_target_group_arn
   private_subnet_ids                   = module.networking.private_subnet_ids
   redis_connection_string              = module.redis.redis_connection_string

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -90,6 +90,7 @@ module "front_door" {
 
   prefix            = local.prefix
   application_port  = local.application_port
+  ecs_security_group_id   = module.application.ecs_security_group_id
   public_subnet_ids = module.networking.public_subnet_ids
   vpc_id            = module.networking.vpc_id
 }


### PR DESCRIPTION
As mentioned in a comment on the [ticket](https://dluhcdigital.atlassian.net/browse/CLDC-2710), there was a mistake in the load balancer egress rule (`load_balancer_container_egress`). This has been fixed as part of this PR.