### PR TITLE
CLDC-2545: set up CloudFront

### DIFF
--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -1,0 +1,47 @@
+locals {
+  origin_id       = "${var.prefix}-origin"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas
+
+  origin {
+    domain_name = aws_lb.main.dns_name
+    origin_id   = local.origin_id
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_keepalive_timeout = 60
+      origin_protocol_policy   = "match-viewer"
+      origin_read_timeout      = 60
+      origin_ssl_protocols     = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD", "OPTIONS"]
+    cache_policy_id          = aws_cloudfront_cache_policy.ttl_based.id
+    compress                 = true
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.this.id
+    target_origin_id         = local.origin_id
+    viewer_protocol_policy   = "allow-all"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Name = "${var.prefix}-cloudfront"
+  }
+}

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -14,6 +14,7 @@ resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV_AWS_86:TODO we will be implementing logging later
   #checkov:skip=CKV_AWS_174:TODO CLDC-2680
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
+  #checkov:skip=CKV_AWS_310:we have decided that we're unlikely to need a secondary load balancer
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -2,7 +2,18 @@ locals {
   origin_id       = "${var.prefix}-origin"
 }
 
+#tfsec:ignore:aws-cloudfront-enable-logging:TODO we will be implementing logging later
+#tfsec:ignore:aws-cloudfront-enable-waf:TODO CLDC-2546
+#tfsec:ignore:aws-cloudfront-enforce-https:TODO CLDC-2654
+#tfsec:ignore:aws-cloudfront-use-secure-tls-policy:TODO CLDC-2680
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_34:TODO CLDC-2654
+  #checkov:skip=CKV2_AWS_42:TODO CLDC-2680
+  #checkov:skip=CKV2_AWS_47:TODO CLDC-2546 when setting up WAF it should be configured appropriately to mitigate against the Log4j vulnerability https://docs.bridgecrew.io/docs/ensure-aws-cloudfront-attached-wafv2-webacl-is-configured-with-amr-for-log4j-vulnerability
+  #checkov:skip=CKV_AWS_68:TODO CLDC-2546
+  #checkov:skip=CKV_AWS_86:TODO we will be implementing logging later
+  #checkov:skip=CKV_AWS_174:TODO CLDC-2680
+  #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
   enabled = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -16,6 +16,7 @@ resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
   #checkov:skip=CKV_AWS_310:we have decided that we're unlikely to need a secondary load balancer
   enabled         = true
+  http_version    = "http2and3"
   is_ipv6_enabled = true
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas
 

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -25,22 +25,22 @@ resource "aws_cloudfront_distribution" "this" {
     origin_id   = local.origin_id
 
     custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_protocol_policy   = "http-only"
-      origin_ssl_protocols     = ["TLSv1.2"]
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
   default_cache_behavior {
-    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods           = ["GET", "HEAD", "OPTIONS"]
-    cache_policy_id          = aws_cloudfront_cache_policy.ttl_based.id
-    compress                 = true
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.this.id
+    allowed_methods            = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    cache_policy_id            = aws_cloudfront_cache_policy.ttl_based.id
+    compress                   = true
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
     response_headers_policy_id = data.aws_cloudfront_response_headers_policy.this.id
-    target_origin_id         = local.origin_id
-    viewer_protocol_policy   = "allow-all"
+    target_origin_id           = local.origin_id
+    viewer_protocol_policy     = "allow-all"
   }
 
   viewer_certificate {

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -38,7 +38,7 @@ resource "aws_cloudfront_distribution" "this" {
     cache_policy_id          = aws_cloudfront_cache_policy.ttl_based.id
     compress                 = true
     origin_request_policy_id = aws_cloudfront_origin_request_policy.this.id
-    response_headers_policy_id = data.aws_cloudfront_managed_response_headers_policy.this.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.this.id
     target_origin_id         = local.origin_id
     viewer_protocol_policy   = "allow-all"
   }

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -1,5 +1,5 @@
 locals {
-  origin_id       = "${var.prefix}-origin"
+  origin_id = "${var.prefix}-origin"
 }
 
 #tfsec:ignore:aws-cloudfront-enable-logging:TODO we will be implementing logging later
@@ -14,7 +14,7 @@ resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV_AWS_86:TODO we will be implementing logging later
   #checkov:skip=CKV_AWS_174:TODO CLDC-2680
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
-  enabled = true
+  enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas
 

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -38,6 +38,7 @@ resource "aws_cloudfront_distribution" "this" {
     cache_policy_id          = aws_cloudfront_cache_policy.ttl_based.id
     compress                 = true
     origin_request_policy_id = aws_cloudfront_origin_request_policy.this.id
+    response_headers_policy_id = data.aws_cloudfront_managed_response_headers_policy.this.id
     target_origin_id         = local.origin_id
     viewer_protocol_policy   = "allow-all"
   }

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -27,9 +27,7 @@ resource "aws_cloudfront_distribution" "this" {
     custom_origin_config {
       http_port                = 80
       https_port               = 443
-      origin_keepalive_timeout = 60
       origin_protocol_policy   = "match-viewer"
-      origin_read_timeout      = 60
       origin_ssl_protocols     = ["TLSv1.2"]
     }
   }

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -27,7 +27,7 @@ resource "aws_cloudfront_distribution" "this" {
     custom_origin_config {
       http_port                = 80
       https_port               = 443
-      origin_protocol_policy   = "match-viewer"
+      origin_protocol_policy   = "http-only"
       origin_ssl_protocols     = ["TLSv1.2"]
     }
   }

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -1,0 +1,38 @@
+resource "aws_cloudfront_cache_policy" "ttl_based" {
+  name        = "${var.prefix}-ttl-60"
+  min_ttl     = 1
+  default_ttl = 60
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "all"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "this" {
+  name    = "${var.prefix}-cloudfront-origin-request-policy"
+
+  cookies_config {
+    cookie_behavior = "all"
+  }
+
+  headers_config {
+    header_behavior = "allViewer"
+  }
+
+  query_strings_config {
+    query_string_behavior = "all"
+  }
+}

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -21,6 +21,10 @@ resource "aws_cloudfront_cache_policy" "ttl_based" {
   }
 }
 
+data "aws_cloudfront_managed_response_headers_policy" "this" {
+  name = "SecurityHeadersPolicy"
+}
+
 resource "aws_cloudfront_origin_request_policy" "this" {
   name = "${var.prefix}-cloudfront-origin-request-policy"
 

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -22,7 +22,7 @@ resource "aws_cloudfront_cache_policy" "ttl_based" {
 }
 
 resource "aws_cloudfront_origin_request_policy" "this" {
-  name    = "${var.prefix}-cloudfront-origin-request-policy"
+  name = "${var.prefix}-cloudfront-origin-request-policy"
 
   cookies_config {
     cookie_behavior = "all"

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -21,8 +21,8 @@ resource "aws_cloudfront_cache_policy" "ttl_based" {
   }
 }
 
-data "aws_cloudfront_managed_response_headers_policy" "this" {
-  name = "SecurityHeadersPolicy"
+data "aws_cloudfront_response_headers_policy" "this" {
+  name = "Managed-SecurityHeadersPolicy"
 }
 
 resource "aws_cloudfront_origin_request_policy" "this" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -61,7 +61,7 @@ module "application" {
   source = "../modules/application"
 
   prefix                               = local.prefix
-  app_host                             = "http://core-stag-load-balancer-1832593432.eu-west-2.elb.amazonaws.com"
+  app_host                             = ""
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
   bulk_upload_bucket_details           = module.bulk_upload.details


### PR DESCRIPTION
Basic cloudfront distribution with minimal encryption settings implemented (this will be done in later tickets).

Note that there doesn't seem to be good Terraform documentation for all the config options. Instead I used the CloudFront API documentation to understand what all the options were: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_Types.html.