### PR TITLE
CLDC-2711: Standardise resource names

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -69,7 +69,7 @@ module "application" {
   database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
   database_port                        = local.database_port
   db_security_group_id                 = module.database.rds_security_group_id
-  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
   ecs_task_cpu                         = 512
   ecs_task_desired_count               = 2
   ecs_task_memory                      = 1024

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -1,5 +1,5 @@
 #tfsec:ignore:aws-ecs-enable-container-insight:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
-resource "aws_ecs_cluster" "main" {
+resource "aws_ecs_cluster" "this" {
   #checkov:skip=CKV_AWS_65:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
   name = "${var.prefix}"
 }
@@ -167,7 +167,7 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
   }
 }
 
-resource "aws_ecs_service" "main" {
+resource "aws_ecs_service" "this" {
   name                               = "${var.prefix}"
   cluster                            = aws_ecs_cluster.main.arn
   deployment_maximum_percent         = 200

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -55,7 +55,7 @@ resource "aws_ecs_task_definition" "template" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.main.id
+          awslogs-group         = aws_cloudwatch_log_group.this.id
           awslogs-region        = "eu-west-2"
           awslogs-stream-prefix = var.prefix
         }
@@ -121,7 +121,7 @@ resource "aws_ecs_task_definition" "main" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.main.id
+          awslogs-group         = aws_cloudwatch_log_group.this.id
           awslogs-region        = "eu-west-2"
           awslogs-stream-prefix = var.prefix
         }
@@ -169,7 +169,7 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
 
 resource "aws_ecs_service" "this" {
   name                               = "${var.prefix}"
-  cluster                            = aws_ecs_cluster.main.arn
+  cluster                            = aws_ecs_cluster.this.arn
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100 / var.ecs_task_desired_count # always 1 task from the desired count should be running
   desired_count                      = var.ecs_task_desired_count
@@ -186,7 +186,7 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.ecs.id]
+    security_groups  = [aws_security_group.this.id]
     subnets          = var.private_subnet_ids
     assign_public_ip = false
   }

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-ecs-enable-container-insight:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
 resource "aws_ecs_cluster" "this" {
   #checkov:skip=CKV_AWS_65:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
-  name = "${var.prefix}"
+  name = var.prefix
 }
 
 locals {
@@ -168,7 +168,7 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
 }
 
 resource "aws_ecs_service" "this" {
-  name                               = "${var.prefix}"
+  name                               = var.prefix
   cluster                            = aws_ecs_cluster.this.arn
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100 / var.ecs_task_desired_count # always 1 task from the desired count should be running

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-ecs-enable-container-insight:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
 resource "aws_ecs_cluster" "main" {
   #checkov:skip=CKV_AWS_65:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
-  name = "${var.prefix}-ecs-cluster"
+  name = "${var.prefix}"
 }
 
 locals {
@@ -168,7 +168,7 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
 }
 
 resource "aws_ecs_service" "main" {
-  name                               = "${var.prefix}-ecs-service"
+  name                               = "${var.prefix}"
   cluster                            = aws_ecs_cluster.main.arn
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100 / var.ecs_task_desired_count # always 1 task from the desired count should be running

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -20,72 +20,6 @@ locals {
   ]
 }
 
-resource "aws_ecs_task_definition" "template" {
-  #checkov:skip=CKV_AWS_336:using readonlyRootFilesystem to true breaks the app, as it needs to write to app/tmp/pids for example
-  family                   = "${var.prefix}-app-template"
-  cpu                      = var.ecs_task_cpu
-  execution_role_arn       = aws_iam_role.task_execution.arn
-  memory                   = var.ecs_task_memory #MiB
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  task_role_arn            = aws_iam_role.task.arn
-
-  container_definitions = jsonencode([
-    {
-      name = local.container_name
-      cpu  = var.ecs_task_cpu
-      environment = [
-        { Name = "API_USER", Value = "dluhc-user" },
-        { Name = "APP_HOST", Value = var.app_host },
-        { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
-        { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
-        { Name = "IMPORT_PAAS_INSTANCE", Value = "" },
-        { Name = "RAILS_ENV", Value = var.rails_env },
-        { Name = "RAILS_LOG_TO_STDOUT", Value = "true" },
-        { Name = "RAILS_SERVE_STATIC_FILES", Value = "true" },
-        { Name = "REDIS_INSTANCE_NAME", Value = "" },
-        { Name = "REDIS_CONFIG", Value = "[{\"instance_name\":\"\",\"credentials\":{\"uri\":\"${var.redis_connection_string}\"}}]" },
-        { Name = "S3_CONFIG", Value = jsonencode(local.s3_config) }
-      ]
-      essential         = true
-      image             = var.ecr_repository_url
-      memoryReservation = var.ecs_task_memory * 0.75
-      user              = "nonroot"
-
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.id
-          awslogs-region        = "eu-west-2"
-          awslogs-stream-prefix = var.prefix
-        }
-      }
-
-      portMappings = [
-        {
-          protocol      = "tcp"
-          containerPort = var.application_port
-          hostPort      = var.application_port
-        }
-      ]
-
-      secrets = [
-        { Name = "API_KEY", valueFrom = aws_secretsmanager_secret.api_key.arn },
-        { Name = "DATABASE_URL", valueFrom = var.database_connection_string_arn },
-        { Name = "GOVUK_NOTIFY_API_KEY", valueFrom = aws_secretsmanager_secret.govuk_notify_api_key.arn },
-        { Name = "OS_DATA_KEY", valueFrom = aws_secretsmanager_secret.os_data_key.arn },
-        { Name = "RAILS_MASTER_KEY", valueFrom = aws_secretsmanager_secret.rails_master_key.arn },
-        { Name = "SENTRY_DSN", valueFrom = aws_secretsmanager_secret.sentry_dsn.arn }
-      ]
-    }
-  ])
-
-  runtime_platform {
-    operating_system_family = "LINUX"
-    cpu_architecture        = "X86_64"
-  }
-}
-
 resource "aws_ecs_task_definition" "main" {
   #checkov:skip=CKV_AWS_336:using readonlyRootFilesystem to true breaks the app, as it needs to write to app/tmp/pids for example
   family                   = "${var.prefix}-ecs-task"
@@ -154,7 +88,7 @@ resource "aws_ecs_task_definition" "main" {
 
 resource "aws_ecs_task_definition" "ad_hoc_tasks" {
   #checkov:skip=CKV_AWS_336:using readonlyRootFilesystem to true breaks the app, as it needs to write to app/tmp/pids for example
-  family = "${var.prefix}-ad-hoc"
+  family                   = "${var.prefix}-ad-hoc"
   cpu                      = var.ecs_task_cpu
   execution_role_arn       = aws_iam_role.task_execution.arn
   memory                   = var.ecs_task_memory #MiB
@@ -162,12 +96,55 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = aws_iam_role.task.arn
 
-  container_definitions = jsonencode([{
-    name              = local.container_name
-    image             = var.ecr_repository_url
-    user              = "nonroot"
-    memoryReservation = var.ecs_task_memory * 0.75
-  }])
+  container_definitions = jsonencode([
+    {
+      name = local.container_name
+      cpu  = var.ecs_task_cpu
+      environment = [
+        { Name = "API_USER", Value = "dluhc-user" },
+        { Name = "APP_HOST", Value = var.app_host },
+        { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
+        { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
+        { Name = "IMPORT_PAAS_INSTANCE", Value = "" },
+        { Name = "RAILS_ENV", Value = var.rails_env },
+        { Name = "RAILS_LOG_TO_STDOUT", Value = "true" },
+        { Name = "RAILS_SERVE_STATIC_FILES", Value = "true" },
+        { Name = "REDIS_INSTANCE_NAME", Value = "" },
+        { Name = "REDIS_CONFIG", Value = "[{\"instance_name\":\"\",\"credentials\":{\"uri\":\"${var.redis_connection_string}\"}}]" },
+        { Name = "S3_CONFIG", Value = jsonencode(local.s3_config) }
+      ]
+      essential         = true
+      image             = var.ecr_repository_url
+      memoryReservation = var.ecs_task_memory * 0.75
+      user              = "nonroot"
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.id
+          awslogs-region        = "eu-west-2"
+          awslogs-stream-prefix = var.prefix
+        }
+      }
+
+      portMappings = [
+        {
+          protocol      = "tcp"
+          containerPort = var.application_port
+          hostPort      = var.application_port
+        }
+      ]
+
+      secrets = [
+        { Name = "API_KEY", valueFrom = aws_secretsmanager_secret.api_key.arn },
+        { Name = "DATABASE_URL", valueFrom = var.database_connection_string_arn },
+        { Name = "GOVUK_NOTIFY_API_KEY", valueFrom = aws_secretsmanager_secret.govuk_notify_api_key.arn },
+        { Name = "OS_DATA_KEY", valueFrom = aws_secretsmanager_secret.os_data_key.arn },
+        { Name = "RAILS_MASTER_KEY", valueFrom = aws_secretsmanager_secret.rails_master_key.arn },
+        { Name = "SENTRY_DSN", valueFrom = aws_secretsmanager_secret.sentry_dsn.arn }
+      ]
+    }
+  ])
 
   runtime_platform {
     operating_system_family = "LINUX"
@@ -175,8 +152,10 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
   }
 
   lifecycle {
-    # This definition will be updated on deployments based on the template definition
-    ignore_changes = all
+    # The image will be updated by deployments - irritatingly we can't ignore changes just to the image
+    # If changing other aspects of the container definition we'll need to temporarily not ignore changes
+    # to force the update
+    ignore_changes = [container_definitions]
   }
 }
 
@@ -199,7 +178,7 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.this.id]
+    security_groups  = [aws_security_group.ecs.id]
     subnets          = var.private_subnet_ids
     assign_public_ip = false
   }

--- a/terraform/modules/application/logging.tf
+++ b/terraform/modules/application/logging.tf
@@ -1,6 +1,6 @@
 # TODO CLDC-2542 remove/modify this temporary logging setup
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key:TODO CLDC-2542 create and encrypt with a KMS key if retaining this log group
-resource "aws_cloudwatch_log_group" "main" {
+resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:TODO CLDC-2542 create and encrypt with a KMS key if retaining this log group
   #checkov:skip=CKV_AWS_338:TODO CLDC-2542 retaining logs for at least 1year greater than necessary for debugging ecs
   name              = "${var.prefix}-ecs-debugging-log"

--- a/terraform/modules/application/outputs.tf
+++ b/terraform/modules/application/outputs.tf
@@ -1,4 +1,4 @@
 output "ecs_security_group_id" {
-  value       = aws_security_group.ecs.id
+  value       = aws_security_group.this.id
   description = "The id of the ecs security group"
 }

--- a/terraform/modules/application/outputs.tf
+++ b/terraform/modules/application/outputs.tf
@@ -1,4 +1,4 @@
 output "ecs_security_group_id" {
-  value       = aws_security_group.this.id
+  value       = aws_security_group.ecs.id
   description = "The id of the ecs security group"
 }

--- a/terraform/modules/application/role_deployment.tf
+++ b/terraform/modules/application/role_deployment.tf
@@ -21,23 +21,28 @@ data "aws_iam_policy_document" "allow_deployment" {
   statement {
     actions = [
       "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition"
+      "ecs:RegisterTaskDefinition",
+      "ecs:DescribeTasks"
     ]
     resources = ["*"]
     effect    = "Allow"
   }
 
   statement {
-    actions = ["iam:PassRole"]
+    actions = [
+      "iam:PassRole"
+    ]
     resources = [
-        aws_iam_role.task.arn,
-        aws_iam_role.task_execution.arn
+      aws_iam_role.task.arn,
+      aws_iam_role.task_execution.arn
     ]
     effect = "Allow"
   }
 
   statement {
-    actions = ["ecs:RunTask"]
+    actions = [
+      "ecs:RunTask"
+    ]
     resources = [
       aws_ecs_task_definition.ad_hoc_tasks.arn_without_revision,
       aws_ecs_task_definition.main.arn_without_revision

--- a/terraform/modules/application/role_deployment.tf
+++ b/terraform/modules/application/role_deployment.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "allow_deployment" {
       "ecs:DescribeServices",
       "ecs:UpdateService"
     ]
-    resources = [aws_ecs_service.main.id]
+    resources = [aws_ecs_service.this.id]
     effect    = "Allow"
   }
 }

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -14,7 +14,7 @@ resource "aws_vpc_security_group_ingress_rule" "load_balancer_ingress" {
   from_port                    = var.application_port
   to_port                      = var.application_port
   referenced_security_group_id = var.load_balancer_security_group_id
-  security_group_id            = aws_security_group.ecs.id
+  security_group_id            = aws_security_group.this.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "db_egress" {
@@ -23,7 +23,7 @@ resource "aws_vpc_security_group_egress_rule" "db_egress" {
   from_port                    = var.database_port
   to_port                      = var.database_port
   referenced_security_group_id = var.db_security_group_id
-  security_group_id            = aws_security_group.ecs.id
+  security_group_id            = aws_security_group.this.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "redis_egress" {
@@ -32,7 +32,7 @@ resource "aws_vpc_security_group_egress_rule" "redis_egress" {
   from_port                    = var.redis_port
   to_port                      = var.redis_port
   referenced_security_group_id = var.redis_security_group_id
-  security_group_id            = aws_security_group.ecs.id
+  security_group_id            = aws_security_group.this.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "http_egress" {
@@ -41,7 +41,7 @@ resource "aws_vpc_security_group_egress_rule" "http_egress" {
   ip_protocol       = "tcp"
   from_port         = 80
   to_port           = 80
-  security_group_id = aws_security_group.ecs.id
+  security_group_id = aws_security_group.this.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "https_egress" {
@@ -50,5 +50,5 @@ resource "aws_vpc_security_group_egress_rule" "https_egress" {
   ip_protocol       = "tcp"
   from_port         = 443
   to_port           = 443
-  security_group_id = aws_security_group.ecs.id
+  security_group_id = aws_security_group.this.id
 }

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "ecs" {
+resource "aws_security_group" "this" {
   name        = "${var.prefix}-ecs"
   description = "ECS security group"
   vpc_id      = var.vpc_id
@@ -8,7 +8,7 @@ resource "aws_security_group" "ecs" {
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "ecs_ingress" {
+resource "aws_vpc_security_group_ingress_rule" "load_balancer_ingress" {
   description                  = "Allow ingress on port ${var.application_port} from the load balancer"
   ip_protocol                  = "tcp"
   from_port                    = var.application_port
@@ -17,7 +17,7 @@ resource "aws_vpc_security_group_ingress_rule" "ecs_ingress" {
   security_group_id            = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "ecs_db_egress" {
+resource "aws_vpc_security_group_egress_rule" "db_egress" {
   description                  = "Allow egress to the database"
   ip_protocol                  = "tcp"
   from_port                    = var.database_port
@@ -26,7 +26,7 @@ resource "aws_vpc_security_group_egress_rule" "ecs_db_egress" {
   security_group_id            = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "ecs_redis_egress" {
+resource "aws_vpc_security_group_egress_rule" "redis_egress" {
   description                  = "Allow egress to redis"
   ip_protocol                  = "tcp"
   from_port                    = var.redis_port
@@ -35,7 +35,7 @@ resource "aws_vpc_security_group_egress_rule" "ecs_redis_egress" {
   security_group_id            = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "ecs_http_egress" {
+resource "aws_vpc_security_group_egress_rule" "http_egress" {
   description       = "Allow http egress to any IP address"
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "tcp"
@@ -44,7 +44,7 @@ resource "aws_vpc_security_group_egress_rule" "ecs_http_egress" {
   security_group_id = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "ecs_https_egress" {
+resource "aws_vpc_security_group_egress_rule" "https_egress" {
   description       = "Allow https egress to any IP address"
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "tcp"

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "this" {
+resource "aws_security_group" "ecs" {
   name        = "${var.prefix}-ecs"
   description = "ECS security group"
   vpc_id      = var.vpc_id
@@ -8,31 +8,31 @@ resource "aws_security_group" "this" {
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "load_balancer_ingress" {
+resource "aws_vpc_security_group_ingress_rule" "ingress_from_load_balancer" {
   description                  = "Allow ingress on port ${var.application_port} from the load balancer"
   ip_protocol                  = "tcp"
   from_port                    = var.application_port
   to_port                      = var.application_port
   referenced_security_group_id = var.load_balancer_security_group_id
-  security_group_id            = aws_security_group.this.id
+  security_group_id            = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "db_egress" {
+resource "aws_vpc_security_group_egress_rule" "egress_to_db" {
   description                  = "Allow egress to the database"
   ip_protocol                  = "tcp"
   from_port                    = var.database_port
   to_port                      = var.database_port
   referenced_security_group_id = var.db_security_group_id
-  security_group_id            = aws_security_group.this.id
+  security_group_id            = aws_security_group.ecs.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "redis_egress" {
+resource "aws_vpc_security_group_egress_rule" "egress_to_redis" {
   description                  = "Allow egress to redis"
   ip_protocol                  = "tcp"
   from_port                    = var.redis_port
   to_port                      = var.redis_port
   referenced_security_group_id = var.redis_security_group_id
-  security_group_id            = aws_security_group.this.id
+  security_group_id            = aws_security_group.ecs.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "http_egress" {
@@ -41,7 +41,7 @@ resource "aws_vpc_security_group_egress_rule" "http_egress" {
   ip_protocol       = "tcp"
   from_port         = 80
   to_port           = 80
-  security_group_id = aws_security_group.this.id
+  security_group_id = aws_security_group.ecs.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "https_egress" {
@@ -50,5 +50,5 @@ resource "aws_vpc_security_group_egress_rule" "https_egress" {
   ip_protocol       = "tcp"
   from_port         = 443
   to_port           = 443
-  security_group_id = aws_security_group.this.id
+  security_group_id = aws_security_group.ecs.id
 }

--- a/terraform/modules/application/security_groups.tf
+++ b/terraform/modules/application/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "ecs" {
-  name        = "${var.prefix}-ecs-security_group"
+  name        = "${var.prefix}-ecs"
   description = "ECS security group"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "this" {
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication is overkill when this is only for data transfer
   #checkov:skip=CKV_AWS_21: versioning not important, each upload creates a new file with a different name (a random UUID)
-  bucket = "${var.prefix}-bulk-upload-bucket"
+  bucket = "${var.prefix}-bulk-upload"
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "this" {
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication is overkill when this is only for data transfer
   #checkov:skip=CKV_AWS_21: versioning not important, data source is elsewhere
-  bucket = "${var.prefix}-export-bucket"
+  bucket = "${var.prefix}-export"
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -12,7 +12,7 @@ terraform {
 #tfsec:ignore:aws-ecr-repository-customer-key:encryption using KMS CMK not required
 resource "aws_ecr_repository" "this" {
   #checkov:skip=CKV_AWS_136:encryption using KMS not required
-  name                 = "core-ecr"
+  name                 = "core"
   image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,10 +1,10 @@
 output "redis_connection_string" {
-  value       = "redis://${aws_elasticache_cluster.main.cache_nodes[0].address}:${aws_elasticache_cluster.main.cache_nodes[0].port}"
+  value       = "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.cache_nodes[0].port}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }
 
 output "redis_security_group_id" {
-  value       = aws_security_group.redis.id
+  value       = aws_security_group.this.id
   description = "The id of the redis security group"
 }

--- a/terraform/modules/elasticache/parameter_groups.tf
+++ b/terraform/modules/elasticache/parameter_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_elasticache_parameter_group" "main" {
+resource "aws_elasticache_parameter_group" "this" {
   name = "${var.prefix}"
   # Ensure the redis version below tallies with the engine_version defined for the redis elasticache cluster (see redis.tf)
   # Parameter group families are outlined here - https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html

--- a/terraform/modules/elasticache/parameter_groups.tf
+++ b/terraform/modules/elasticache/parameter_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_elasticache_parameter_group" "main" {
-  name = "${var.prefix}-redis-parameter-group"
+  name = "${var.prefix}"
   # Ensure the redis version below tallies with the engine_version defined for the redis elasticache cluster (see redis.tf)
   # Parameter group families are outlined here - https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html
   family = "redis6.x"

--- a/terraform/modules/elasticache/parameter_groups.tf
+++ b/terraform/modules/elasticache/parameter_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_elasticache_parameter_group" "this" {
-  name = "${var.prefix}"
+  name = var.prefix
   # Ensure the redis version below tallies with the engine_version defined for the redis elasticache cluster (see redis.tf)
   # Parameter group families are outlined here - https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html
   family = "redis6.x"

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -11,8 +11,8 @@ resource "aws_elasticache_cluster" "this" {
   maintenance_window         = "sun:23:00-mon:01:30"
   node_type                  = var.node_type
   num_cache_nodes            = 1
-  parameter_group_name       = aws_elasticache_parameter_group.main.id
+  parameter_group_name       = aws_elasticache_parameter_group.this.id
   port                       = var.redis_port
-  security_group_ids         = [aws_security_group.redis.id]
+  security_group_ids         = [aws_security_group.this.id]
   subnet_group_name          = var.redis_subnet_group_name
 }

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -1,5 +1,5 @@
 #tfsec:ignore:aws-elasticache-enable-backup-retention:TODO CLDC-2679 setup a snapshot retention limit
-resource "aws_elasticache_cluster" "main" {
+resource "aws_elasticache_cluster" "this" {
   #checkov:skip=CKV_AWS_134:TODO CLDC-2679 setup a snapshot retention limit
   #TODO CLDC-2679 setup redis replicas with multi-az and automatic failover
   #TODO CLDC-2682 setup redis logging

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -3,7 +3,7 @@ resource "aws_elasticache_cluster" "main" {
   #checkov:skip=CKV_AWS_134:TODO CLDC-2679 setup a snapshot retention limit
   #TODO CLDC-2679 setup redis replicas with multi-az and automatic failover
   #TODO CLDC-2682 setup redis logging
-  cluster_id                 = "${var.prefix}-redis"
+  cluster_id                 = "${var.prefix}"
   auto_minor_version_upgrade = true
   apply_immediately          = true
   engine                     = "redis"

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -3,7 +3,7 @@ resource "aws_elasticache_cluster" "this" {
   #checkov:skip=CKV_AWS_134:TODO CLDC-2679 setup a snapshot retention limit
   #TODO CLDC-2679 setup redis replicas with multi-az and automatic failover
   #TODO CLDC-2682 setup redis logging
-  cluster_id                 = "${var.prefix}"
+  cluster_id                 = var.prefix
   auto_minor_version_upgrade = true
   apply_immediately          = true
   engine                     = "redis"

--- a/terraform/modules/elasticache/security_groups.tf
+++ b/terraform/modules/elasticache/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "redis" {
+resource "aws_security_group" "this" {
   name        = "${var.prefix}-redis"
   description = "Redis security group"
   vpc_id      = var.vpc_id

--- a/terraform/modules/elasticache/security_groups.tf
+++ b/terraform/modules/elasticache/security_groups.tf
@@ -14,5 +14,5 @@ resource "aws_vpc_security_group_ingress_rule" "redis_ingress" {
   from_port                    = var.redis_port
   to_port                      = var.redis_port
   referenced_security_group_id = var.ecs_security_group_id
-  security_group_id            = aws_security_group.redis.id
+  security_group_id            = aws_security_group.this.id
 }

--- a/terraform/modules/elasticache/security_groups.tf
+++ b/terraform/modules/elasticache/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "redis" {
-  name        = "${var.prefix}-redis-security-group"
+  name        = "${var.prefix}-redis"
   description = "Redis security group"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -64,7 +64,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 }
 
-resource "random_password" "cloudfront_header" {
+resource "random_password" "this" {
   length  = 16
   special = false
 }

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -22,7 +22,7 @@ resource "aws_cloudfront_distribution" "this" {
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas
 
   origin {
-    domain_name = aws_lb.main.dns_name
+    domain_name = aws_lb.this.dns_name
     origin_id   = local.origin_id
 
     custom_origin_config {
@@ -34,14 +34,14 @@ resource "aws_cloudfront_distribution" "this" {
 
     custom_header {
       name  = local.cloudfront_header_name
-      value = random_password.cloudfront_header.result
+      value = random_password.this.result
     }
   }
 
   default_cache_behavior {
     allowed_methods            = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods             = ["GET", "HEAD", "OPTIONS"]
-    cache_policy_id            = aws_cloudfront_cache_policy.ttl_based.id
+    cache_policy_id            = aws_cloudfront_cache_policy.this.id
     compress                   = true
     origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
     response_headers_policy_id = data.aws_cloudfront_response_headers_policy.this.id

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -34,7 +34,7 @@ resource "aws_cloudfront_distribution" "this" {
 
     custom_header {
       name  = local.cloudfront_header_name
-      value = random_password.this.result
+      value = random_password.cloudfront_header.result
     }
   }
 
@@ -64,7 +64,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 }
 
-resource "random_password" "this" {
+resource "random_password" "cloudfront_header" {
   length  = 16
   special = false
 }

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "this" {
   #checkov:skip=CKV_AWS_91:setup access logs on load balancer TODO CLDC-2705
   #checkov:skip=CKV2_AWS_20:redirect http requests to https TODO CLDC-2654
   #checkov:skip=CKV2_AWS_28:WAF protection to be setup TODO CLDC-2546
-  name                       = "${var.prefix}"
+  name                       = var.prefix
   drop_invalid_header_fields = true
   enable_deletion_protection = true
   internal                   = false
@@ -13,7 +13,7 @@ resource "aws_lb" "this" {
 }
 
 resource "aws_lb_target_group" "this" {
-  name        = "${var.prefix}"
+  name        = var.prefix
   port        = var.application_port
   protocol    = "HTTP"
   vpc_id      = var.vpc_id

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "main" {
   #checkov:skip=CKV_AWS_91:setup access logs on load balancer TODO CLDC-2705
   #checkov:skip=CKV2_AWS_20:redirect http requests to https TODO CLDC-2654
   #checkov:skip=CKV2_AWS_28:WAF protection to be setup TODO CLDC-2546
-  name                       = "${var.prefix}-load-balancer"
+  name                       = "${var.prefix}"
   drop_invalid_header_fields = true
   enable_deletion_protection = true
   internal                   = false
@@ -13,7 +13,7 @@ resource "aws_lb" "main" {
 }
 
 resource "aws_lb_target_group" "main" {
-  name        = "${var.prefix}-target-group"
+  name        = "${var.prefix}"
   port        = var.application_port
   protocol    = "HTTP"
   vpc_id      = var.vpc_id

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -65,7 +65,7 @@ resource "aws_lb_listener_rule" "forward_cloudfront" {
   condition {
     http_header {
       http_header_name = local.cloudfront_header_name
-      values           = [random_password.this.result]
+      values           = [random_password.cloudfront_header.result]
     }
   }
 }

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -1,5 +1,5 @@
 #tfsec:ignore:aws-elb-alb-not-public:load balancer is exposed to internet as it receives traffic from public
-resource "aws_lb" "main" {
+resource "aws_lb" "this" {
   #checkov:skip=CKV_AWS_91:setup access logs on load balancer TODO CLDC-2705
   #checkov:skip=CKV2_AWS_20:redirect http requests to https TODO CLDC-2654
   #checkov:skip=CKV2_AWS_28:WAF protection to be setup TODO CLDC-2546
@@ -12,7 +12,7 @@ resource "aws_lb" "main" {
   subnets                    = var.public_subnet_ids
 }
 
-resource "aws_lb_target_group" "main" {
+resource "aws_lb_target_group" "this" {
   name        = "${var.prefix}"
   port        = var.application_port
   protocol    = "HTTP"

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -34,7 +34,7 @@ resource "aws_lb_target_group" "this" {
 resource "aws_lb_listener" "http" {
   #checkov:skip=CKV_AWS_103:ssl policy for https listener will be implemented here TODO CLDC-2654
   #checkov:skip=CKV_AWS_2:https between cloudfront and load balancer will be implemented here TODO CLDC-2654
-  load_balancer_arn = aws_lb.main.id
+  load_balancer_arn = aws_lb.this.id
   port              = 80
   protocol          = "HTTP"
 
@@ -49,7 +49,7 @@ resource "aws_lb_listener" "http" {
   }
 
   lifecycle {
-    replace_triggered_by = [aws_lb_target_group.main.id]
+    replace_triggered_by = [aws_lb_target_group.this.id]
   }
 }
 
@@ -58,14 +58,14 @@ resource "aws_lb_listener_rule" "forward_cloudfront" {
   priority     = 1
 
   action {
-    target_group_arn = aws_lb_target_group.main.id
+    target_group_arn = aws_lb_target_group.this.id
     type             = "forward"
   }
 
   condition {
     http_header {
       http_header_name = local.cloudfront_header_name
-      values           = [random_password.cloudfront_header.result]
+      values           = [random_password.this.result]
     }
   }
 }

--- a/terraform/modules/front_door/outputs.tf
+++ b/terraform/modules/front_door/outputs.tf
@@ -4,6 +4,6 @@ output "load_balancer_security_group_id" {
 }
 
 output "load_balancer_target_group_arn" {
-  value       = aws_lb_target_group.main.arn
+  value       = aws_lb_target_group.this.arn
   description = "The arn of the load balancer target group to be associated with the ecs"
 }

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudfront_cache_policy" "ttl_based" {
+resource "aws_cloudfront_cache_policy" "this" {
   name        = "${var.prefix}"
   min_ttl     = 1
   default_ttl = 60

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_cache_policy" "this" {
-  name        = "${var.prefix}"
+  name        = var.prefix
   min_ttl     = 1
   default_ttl = 60
 
@@ -26,7 +26,7 @@ data "aws_cloudfront_response_headers_policy" "this" {
 }
 
 resource "aws_cloudfront_origin_request_policy" "this" {
-  name = "${var.prefix}"
+  name = var.prefix
 
   cookies_config {
     cookie_behavior = "all"

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudfront_cache_policy" "ttl_based" {
-  name        = "${var.prefix}-ttl-60"
+  name        = "${var.prefix}"
   min_ttl     = 1
   default_ttl = 60
 
@@ -26,7 +26,7 @@ data "aws_cloudfront_response_headers_policy" "this" {
 }
 
 resource "aws_cloudfront_origin_request_policy" "this" {
-  name = "${var.prefix}-cloudfront-origin-request-policy"
+  name = "${var.prefix}"
 
   cookies_config {
     cookie_behavior = "all"

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "load_balancer" {
-  name        = "${var.prefix}-load-balancer-security-group"
+  name        = "${var.prefix}-load-balancer"
   description = "Load Balancer security group"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/github_actions_access/app_repo_role.tf
+++ b/terraform/modules/github_actions_access/app_repo_role.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "push_images" {
 }
 
 resource "aws_iam_policy" "push_images" {
-  name   = "core-push-ecr-images"
+  name   = "core-ecr-push-images"
   policy = data.aws_iam_policy_document.push_images.json
 }
 

--- a/terraform/modules/github_actions_access/app_repo_role.tf
+++ b/terraform/modules/github_actions_access/app_repo_role.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "push_images" {
 }
 
 resource "aws_iam_policy" "push_images" {
-  name   = "push-ecr-images"
+  name   = "core-push-ecr-images"
   policy = data.aws_iam_policy_document.push_images.json
 }
 

--- a/terraform/modules/github_actions_access/openid_connect.tf
+++ b/terraform/modules/github_actions_access/openid_connect.tf
@@ -1,4 +1,4 @@
-resource "aws_iam_openid_connect_provider" "github_oidc" {
+resource "aws_iam_openid_connect_provider" "this" {
   url = "https://token.actions.githubusercontent.com"
 
   client_id_list = ["sts.amazonaws.com"]

--- a/terraform/modules/networking/gateways.tf
+++ b/terraform/modules/networking/gateways.tf
@@ -1,4 +1,4 @@
-resource "aws_internet_gateway" "main" {
+resource "aws_internet_gateway" "this" {
   vpc_id = aws_vpc.main.id
 
   tags = {
@@ -18,7 +18,7 @@ resource "aws_eip" "nat_gateway" {
   depends_on = [aws_internet_gateway.main]
 }
 
-resource "aws_nat_gateway" "main" {
+resource "aws_nat_gateway" "this" {
   count         = length(aws_subnet.private)
   allocation_id = element(aws_eip.nat_gateway[*].id, count.index)
   subnet_id     = element(aws_subnet.public[*].id, count.index)

--- a/terraform/modules/networking/gateways.tf
+++ b/terraform/modules/networking/gateways.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "this" {
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.this.id
 
   tags = {
     Name = "${var.prefix}-internet-gateway"
@@ -15,7 +15,7 @@ resource "aws_eip" "nat_gateway" {
     Name = "${var.prefix}-nat-gateway-eip-${count.index}"
   }
 
-  depends_on = [aws_internet_gateway.main]
+  depends_on = [aws_internet_gateway.this]
 }
 
 resource "aws_nat_gateway" "this" {
@@ -27,5 +27,5 @@ resource "aws_nat_gateway" "this" {
     Name = "${var.prefix}-nat-gateway-${count.index}"
   }
 
-  depends_on = [aws_internet_gateway.main]
+  depends_on = [aws_internet_gateway.this]
 }

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,5 +1,5 @@
 output "db_private_subnet_group_name" {
-  value       = aws_db_subnet_group.private.name
+  value       = aws_db_subnet_group.this.name
   description = "The name of the private subnet group for the db"
 }
 
@@ -19,11 +19,11 @@ output "public_subnet_ids" {
 }
 
 output "redis_private_subnet_group_name" {
-  value       = aws_elasticache_subnet_group.private.name
+  value       = aws_elasticache_subnet_group.this.name
   description = "The name of the private subnet group for redis"
 }
 
 output "vpc_id" {
-  value       = aws_vpc.main.id
+  value       = aws_vpc.this.id
   description = "The id of the main vpc"
 }

--- a/terraform/modules/networking/routing.tf
+++ b/terraform/modules/networking/routing.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.main.id
+  vpc_id = aws_vpc.this.id
 
   tags = {
     Name = "${var.prefix}-public-route-table"
@@ -9,7 +9,7 @@ resource "aws_route_table" "public" {
 resource "aws_route" "to_internet_gateway" {
   route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.main.id
+  gateway_id             = aws_internet_gateway.this.id
 }
 
 resource "aws_route_table_association" "public" {
@@ -19,8 +19,8 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route_table" "private" {
-  count  = length(aws_nat_gateway.main)
-  vpc_id = aws_vpc.main.id
+  count  = length(aws_nat_gateway.this)
+  vpc_id = aws_vpc.this.id
 
   tags = {
     Name = "${var.prefix}-private-route-table-${count.index}"
@@ -28,10 +28,10 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "to_nat_gateway" {
-  count                  = length(aws_nat_gateway.main)
+  count                  = length(aws_nat_gateway.this)
   route_table_id         = element(aws_route_table.private[*].id, count.index)
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = element(aws_nat_gateway.main[*].id, count.index)
+  nat_gateway_id         = element(aws_nat_gateway.this[*].id, count.index)
 }
 
 resource "aws_route_table_association" "private" {

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -29,12 +29,12 @@ resource "aws_subnet" "private" {
   }
 }
 
-resource "aws_db_subnet_group" "private" {
+resource "aws_db_subnet_group" "this" {
   name       = "${var.prefix}"
   subnet_ids = aws_subnet.private[*].id
 }
 
-resource "aws_elasticache_subnet_group" "private" {
+resource "aws_elasticache_subnet_group" "this" {
   name       = "${var.prefix}"
   subnet_ids = aws_subnet.private[*].id
 }

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -30,11 +30,11 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_db_subnet_group" "this" {
-  name       = "${var.prefix}"
+  name       = var.prefix
   subnet_ids = aws_subnet.private[*].id
 }
 
 resource "aws_elasticache_subnet_group" "this" {
-  name       = "${var.prefix}"
+  name       = var.prefix
   subnet_ids = aws_subnet.private[*].id
 }

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -10,7 +10,7 @@ resource "aws_subnet" "public" {
   availability_zone = "${local.region}${local.availability_zones[count.index]}"
   # Splits the public CIDR block into three parts (one for each AZ)
   cidr_block = cidrsubnet(local.public_subnet_cidr, 2, count.index)
-  vpc_id     = aws_vpc.main.id
+  vpc_id     = aws_vpc.this.id
 
   tags = {
     Name = "${var.prefix}-public-subnet-${local.region}${local.availability_zones[count.index]}"
@@ -22,7 +22,7 @@ resource "aws_subnet" "private" {
   availability_zone = "${local.region}${local.availability_zones[count.index]}"
   # Splits the private CIDR block into three parts (one for each AZ)
   cidr_block = cidrsubnet(local.private_subnet_cidr, 2, count.index)
-  vpc_id     = aws_vpc.main.id
+  vpc_id     = aws_vpc.this.id
 
   tags = {
     Name = "${var.prefix}-private-subnet-${local.region}${local.availability_zones[count.index]}"

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -30,11 +30,11 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_db_subnet_group" "private" {
-  name       = "${var.prefix}-db-private-subnet-group"
+  name       = "${var.prefix}"
   subnet_ids = aws_subnet.private[*].id
 }
 
 resource "aws_elasticache_subnet_group" "private" {
-  name       = "${var.prefix}-redis-private-subnet-group"
+  name       = "${var.prefix}"
   subnet_ids = aws_subnet.private[*].id
 }

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -13,14 +13,14 @@ resource "aws_flow_log" "vpc_accepted" {
   iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_accepted.arn
   traffic_type    = "ACCEPT"
-  vpc_id          = aws_vpc.main.id
+  vpc_id          = aws_vpc.this.id
 }
 
 resource "aws_flow_log" "vpc_rejected" {
   iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_rejected.arn
   traffic_type    = "REJECT"
-  vpc_id          = aws_vpc.main.id
+  vpc_id          = aws_vpc.this.id
 }
 
 # tfsec:ignore:aws-cloudwatch-log-group-customer-key:flow logs are non-sensitive

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -1,4 +1,4 @@
-resource "aws_vpc" "main" {
+resource "aws_vpc" "this" {
   #checkov:skip=CKV2_AWS_12:we don't think that we should restrict all traffic on the default VPC security group, otherwise our application will be completely isolated
   cidr_block           = var.vpc_cidr_block
   enable_dns_support   = true

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -41,13 +41,13 @@ resource "aws_cloudwatch_log_group" "vpc_flow_logs_rejected" {
 
 # https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html#flow-logs-iam-role
 resource "aws_iam_role" "vpc_flow_logs" {
-  name = "${var.prefix}-vpc-flow-logs-role"
+  name = "${var.prefix}-vpc-flow-logs"
 
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_assume_role_permissions.json
 }
 
 resource "aws_iam_role_policy" "vpc_flow_logs" {
-  name = "${var.prefix}-vpc-flow-logs-cloudwatch-policy"
+  name = "${var.prefix}-vpc-flow-logs"
   role = aws_iam_role.vpc_flow_logs.id
 
   policy = data.aws_iam_policy_document.vpc_flow_logs_log_permissions.json

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -20,13 +20,13 @@ resource "aws_db_instance" "this" {
   engine_version             = "13.11"
   instance_class             = var.instance_class
   multi_az                   = true
-  password                   = random_password.password.result
+  password                   = random_password.this.result
   port                       = var.database_port
   publicly_accessible        = false
   storage_encrypted          = true
   storage_type               = "gp2"
   username                   = "postgres"
-  vpc_security_group_ids     = [aws_security_group.rds.id]
+  vpc_security_group_ids     = [aws_security_group.this.id]
 
   lifecycle {
     prevent_destroy = true
@@ -37,5 +37,5 @@ resource "aws_ssm_parameter" "database_connection_string" {
   #checkov:skip=CKV_AWS_337:default encryption not using a kms cmk sufficient
   name  = "DATA_COLLECTOR_DATABASE_URL"
   type  = "SecureString"
-  value = "postgresql://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}/${aws_db_instance.main.db_name}"
+  value = "postgresql://${aws_db_instance.this.username}:${aws_db_instance.this.password}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}"
 }

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "main" {
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
   #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
   #checkov:skip=CKV2_AWS_60:copy tags to snapshots TODO CLDC-2661
-  identifier                 = "${var.prefix}-postgres-db"
+  identifier                 = "${var.prefix}"
   apply_immediately          = true
   auto_minor_version_upgrade = true
   allocated_storage          = var.allocated_storage #units are GiB

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "this" {
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
   #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
   #checkov:skip=CKV2_AWS_60:copy tags to snapshots TODO CLDC-2661
-  identifier                 = "${var.prefix}"
+  identifier                 = var.prefix
   apply_immediately          = true
   auto_minor_version_upgrade = true
   allocated_storage          = var.allocated_storage #units are GiB

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:aws-rds-specify-backup-retention:TODO CLDC-2661
 #tfsec:ignore:aws-rds-enable-performance-insights:TODO CLDC-2660 if necessary
 #tfsec:ignore:AVD-AWS-0176:iam authentication not suitable as tokens only last 15minutes, password authentication preferred
-resource "aws_db_instance" "main" {
+resource "aws_db_instance" "this" {
   #checkov:skip=CKV_AWS_129:cloudwatch logs TODO CLDC-2660
   #checkov:skip=CKV_AWS_118:monitoring TODO CLDC-2660
   #checkov:skip=CKV_AWS_161:iam authentication not suitable as tokens only last 15minutes, password authentication preferred

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,5 +1,5 @@
 output "rds_security_group_id" {
-  value       = aws_security_group.rds.id
+  value       = aws_security_group.this.id
   description = "The id of the rds security group"
 }
 

--- a/terraform/modules/rds/password.tf
+++ b/terraform/modules/rds/password.tf
@@ -1,4 +1,4 @@
-resource "random_password" "password" {
+resource "random_password" "this" {
   length  = 16
   special = false
 }

--- a/terraform/modules/rds/policy.tf
+++ b/terraform/modules/rds/policy.tf
@@ -15,7 +15,7 @@ resource "aws_iam_policy" "rds_data_access" {
           "rds-data:CommitTransaction",
           "rds-data:RollbackTransaction"
         ]
-        Resource = aws_db_instance.main.arn
+        Resource = aws_db_instance.this.arn
       }
     ]
   })

--- a/terraform/modules/rds/security_groups.tf
+++ b/terraform/modules/rds/security_groups.tf
@@ -14,5 +14,5 @@ resource "aws_vpc_security_group_ingress_rule" "db_ingress" {
   from_port                    = var.database_port
   to_port                      = var.database_port
   referenced_security_group_id = var.ecs_security_group_id
-  security_group_id            = aws_security_group.rds.id
+  security_group_id            = aws_security_group.this.id
 }

--- a/terraform/modules/rds/security_groups.tf
+++ b/terraform/modules/rds/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "rds" {
-  name        = "${var.prefix}-rds-security-group"
+  name        = "${var.prefix}-rds"
   description = "RDS security group"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds/security_groups.tf
+++ b/terraform/modules/rds/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "rds" {
+resource "aws_security_group" "this" {
   name        = "${var.prefix}-rds"
   description = "RDS security group"
   vpc_id      = var.vpc_id

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -69,7 +69,7 @@ module "application" {
   database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
   database_port                        = local.database_port
   db_security_group_id                 = module.database.rds_security_group_id
-  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
   ecs_task_cpu                         = 512
   ecs_task_desired_count               = 2
   ecs_task_memory                      = 1024

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 locals {
-  prefix           = "core-stag"
+  prefix           = "core-staging"
   application_port = 8080
   database_port    = 5432
   redis_port       = 6379

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -69,7 +69,7 @@ module "application" {
   database_data_access_policy_arn      = module.database.rds_data_access_policy_arn
   database_port                        = local.database_port
   db_security_group_id                 = module.database.rds_security_group_id
-  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core-ecr"
+  ecr_repository_url                   = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
   ecs_task_cpu                         = 512
   ecs_task_desired_count               = 2
   ecs_task_memory                      = 1024


### PR DESCRIPTION
You may find this PR easier to review commit-by-commit, as it's nicely separated into distinct chunks.

This PR includes:
- Updating names of resources in AWS
- Updating names of blocks in Terraform code (**if you don't think this is worth changing, I can revert these commits**)

Here are a few resources I didn't rename:
- State buckets (since we probably don't want to be messing around with them now!)
- Task definitions (since you've been working on these)
- Most logging stuff (as that will get reviewed and possibly updated in the logging tickets)
- The name of the db (data_collector) (since I think that's what the app is expecting, although I'm not 100% on that)
- The EIP associated with the NAT gateway (since I imagine we might have more EIPs at some point)
- The `app_repo` role block (since I imagine we'll have more roles in the module in the future, e.g. one for interacting with ECS?)

And here I have a question:
- Do we maybe want to rename the `<env>-export` bucket? In case we have different types of exports in the future?