### PR TITLE
CLDC-2546: Set up WAF

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -109,7 +109,6 @@ module "front_door" {
   prefix                = local.prefix
   application_port      = local.application_port
   ecs_security_group_id = module.application.ecs_security_group_id
-  provider_role_arn     = local.provider_role_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -26,6 +26,15 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
 locals {
   prefix            = "core-dev"
   application_port  = 8080
@@ -92,6 +101,10 @@ module "database" {
 
 module "front_door" {
   source = "../modules/front_door"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   prefix                = local.prefix
   application_port      = local.application_port

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -22,15 +22,16 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::837698168072:role/developer"
+    role_arn = local.provider_role_arn
   }
 }
 
 locals {
-  prefix           = "core-dev"
-  application_port = 8080
-  database_port    = 5432
-  redis_port       = 6379
+  prefix            = "core-dev"
+  application_port  = 8080
+  database_port     = 5432
+  provider_role_arn = "arn:aws:iam::837698168072:role/developer"
+  redis_port        = 6379
 }
 
 module "application" {
@@ -95,6 +96,7 @@ module "front_door" {
   prefix                = local.prefix
   application_port      = local.application_port
   ecs_security_group_id = module.application.ecs_security_group_id
+  provider_role_arn     = local.provider_role_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -22,8 +22,21 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::815624722760:role/developer"
+    role_arn = local.provider_role_arn
   }
+}
+
+provider "aws" {
+  alias  = "eu-west-1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+locals {
+  provider_role_arn = "arn:aws:iam::815624722760:role/developer"
 }
 
 # We create two backends for managing the terraform state of different accounts:
@@ -32,11 +45,19 @@ provider "aws" {
 module "non_prod_backend" {
   source = "../modules/backend"
 
+  providers = {
+    aws.eu-west-1 = aws.eu-west-1
+  }
+
   prefix = "core-non-prod"
 }
 
 module "prod_backend" {
   source = "../modules/backend"
+
+  providers = {
+    aws.eu-west-1 = aws.eu-west-1
+  }
 
   prefix = "core-prod"
 }

--- a/terraform/modules/backend/main.tf
+++ b/terraform/modules/backend/main.tf
@@ -5,18 +5,8 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~>5.0"
+      configuration_aliases = [aws.eu-west-1]
     }
-  }
-}
-
-# The state replica bucket is kept in a separate region (eu-west-1) to the source bucket and where we generally
-# create our infrastructure (eu-west-2), so we define a provider here especially for this
-provider "aws" {
-  alias  = "ireland"
-  region = "eu-west-1"
-
-  assume_role {
-    role_arn = "arn:aws:iam::815624722760:role/developer"
   }
 }
 
@@ -154,7 +144,7 @@ module "tf_state_replica_log_bucket" {
   #checkov:skip=CKV_AWS_300:lifecycle configuration is set below for aborting failed uploads, looks like a false flag
   #checkov:skip=CKV2_AWS_34:use of ssm to store a parameter for the access key of an iam user isn't required nor created by cloudposse with our configuration, so we don't need to ensure encryption of the parameter
   #checkov:skip=CKV2_AWS_62:we don't require event notifications on this bucket as its storing logs continuously and will become a nuisance
-  providers = { aws = aws.ireland }
+  providers = { aws = aws.eu-west-1 }
   source    = "cloudposse/s3-bucket/aws"
   # Cloud Posse recommends pinning every module to a specific version
   version = "3.1.2"
@@ -206,7 +196,7 @@ module "tf_state_replica_bucket" {
   #checkov:skip=CKV_AWS_300:lifecycle configuration is set below for aborting failed uploads, looks like a false flag
   #checkov:skip=CKV2_AWS_34:use of ssm to store a parameter for the access key of an iam user isn't required nor created by cloudposse with our configuration, so we don't need to ensure encryption of the parameter
   #checkov:skip=CKV2_AWS_62:we don't require event notifications on this bucket as it's only replicating the tfstate files as a fallback
-  providers = { aws = aws.ireland }
+  providers = { aws = aws.eu-west-1 }
   source    = "cloudposse/s3-bucket/aws"
   # Cloud Posse recommends pinning every module to a specific version
   version = "3.1.2"

--- a/terraform/modules/backend/main.tf
+++ b/terraform/modules/backend/main.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~>5.0"
+      source                = "hashicorp/aws"
+      version               = "~>5.0"
       configuration_aliases = [aws.eu-west-1]
     }
   }

--- a/terraform/modules/backend/main.tf
+++ b/terraform/modules/backend/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 # The state replica bucket is kept in a separate region (eu-west-1) to the source bucket and where we generally
-# create our infrastructure (eu-west-2), so we define a provider here to be especially for this
+# create our infrastructure (eu-west-2), so we define a provider here especially for this
 provider "aws" {
   alias  = "ireland"
   region = "eu-west-1"

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -20,6 +20,7 @@ resource "aws_cloudfront_distribution" "this" {
   http_version    = "http2and3"
   is_ipv6_enabled = true
   price_class     = "PriceClass_100" # Affects which edge locations are used by cloudfront, which affects the latency users will experience in different geographic areas
+  web_acl_id      = aws_wafv2_web_acl.this.arn
 
   origin {
     domain_name = aws_lb.this.dns_name

--- a/terraform/modules/front_door/main.tf
+++ b/terraform/modules/front_door/main.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~>5.0"
+      source                = "hashicorp/aws"
+      version               = "~>5.0"
       configuration_aliases = [aws.us-east-1]
     }
     random = {

--- a/terraform/modules/front_door/main.tf
+++ b/terraform/modules/front_door/main.tf
@@ -5,6 +5,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~>5.0"
+      configuration_aliases = [aws.us-east-1]
     }
     random = {
       version = "~>3.5"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -13,11 +13,6 @@ variable "prefix" {
   description = "The prefix to be prepended to resource names."
 }
 
-variable "provider_role_arn" {
-  type        = string
-  description = "The role arn to be assumed by the aws provider"
-}
-
 variable "public_subnet_ids" {
   type        = list(string)
   description = "The ids of all the public subnets"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -13,6 +13,11 @@ variable "prefix" {
   description = "The prefix to be prepended to resource names."
 }
 
+variable "provider_role_arn" {
+  type        = string
+  description = "The role arn to be assumed by the aws provider"
+}
+
 variable "public_subnet_ids" {
   type        = list(string)
   description = "The ids of all the public subnets"

--- a/terraform/modules/front_door/waf.tf
+++ b/terraform/modules/front_door/waf.tf
@@ -1,0 +1,164 @@
+provider "aws" {
+  alias  = "north-virginia"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = var.provider_role_arn
+  }
+}
+
+resource "aws_wafv2_web_acl" "this" {
+  #checkov:skip=CKV2_AWS_31:TODO CLDC-2781 setup WAF logging in cloudwatch
+  name        = var.prefix
+  description = "Web ACL to restrict traffic to CloudFront"
+  provider    = aws.north-virginia
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "waf-metrics"
+    sampled_requests_enabled   = false
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-disreputable-ip-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            allow {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-common-exploit-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-bad-input-exploit-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 4
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-sql-exploit-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 5
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-linux-exploit-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesUnixRuleSet"
+    priority = 6
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesUnixRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-unix-exploit-metrics"
+      sampled_requests_enabled   = true
+    }
+  }
+}

--- a/terraform/modules/front_door/waf.tf
+++ b/terraform/modules/front_door/waf.tf
@@ -1,17 +1,8 @@
-provider "aws" {
-  alias  = "north-virginia"
-  region = "us-east-1"
-
-  assume_role {
-    role_arn = var.provider_role_arn
-  }
-}
-
 resource "aws_wafv2_web_acl" "this" {
   #checkov:skip=CKV2_AWS_31:TODO CLDC-2781 setup WAF logging in cloudwatch
   name        = var.prefix
   description = "Web ACL to restrict traffic to CloudFront"
-  provider    = aws.north-virginia
+  provider    = aws.us-east-1
   scope       = "CLOUDFRONT"
 
   default_action {

--- a/terraform/modules/front_door/waf.tf
+++ b/terraform/modules/front_door/waf.tf
@@ -20,7 +20,7 @@ resource "aws_wafv2_web_acl" "this" {
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "waf-metrics"
+    metric_name                = "waf"
     sampled_requests_enabled   = false
   }
 
@@ -41,7 +41,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-disreputable-ip-metrics"
+      metric_name                = "waf-block-disreputable-ip"
       sampled_requests_enabled   = true
     }
   }
@@ -69,7 +69,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-common-exploit-metrics"
+      metric_name                = "waf-block-common-exploit"
       sampled_requests_enabled   = true
     }
   }
@@ -91,7 +91,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-bad-input-exploit-metrics"
+      metric_name                = "waf-block-bad-input-exploit"
       sampled_requests_enabled   = true
     }
   }
@@ -113,7 +113,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-sql-exploit-metrics"
+      metric_name                = "waf-block-sql-exploit"
       sampled_requests_enabled   = true
     }
   }
@@ -135,7 +135,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-linux-exploit-metrics"
+      metric_name                = "waf-block-linux-exploit"
       sampled_requests_enabled   = true
     }
   }
@@ -157,7 +157,7 @@ resource "aws_wafv2_web_acl" "this" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-unix-exploit-metrics"
+      metric_name                = "waf-block-unix-exploit"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -22,15 +22,16 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::977287343304:role/developer"
+    role_arn = local.provider_role_arn
   }
 }
 
 locals {
-  prefix           = "core-prod"
-  application_port = 8080
-  database_port    = 5432
-  redis_port       = 6379
+  prefix            = "core-prod"
+  application_port  = 8080
+  database_port     = 5432
+  provider_role_arn = "arn:aws:iam::977287343304:role/developer"
+  redis_port        = 6379
 }
 
 module "application" {
@@ -95,6 +96,7 @@ module "front_door" {
   prefix                = local.prefix
   application_port      = local.application_port
   ecs_security_group_id = module.application.ecs_security_group_id
+  provider_role_arn     = local.provider_role_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -109,7 +109,6 @@ module "front_door" {
   prefix                = local.prefix
   application_port      = local.application_port
   ecs_security_group_id = module.application.ecs_security_group_id
-  provider_role_arn     = local.provider_role_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -26,6 +26,15 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
 locals {
   prefix            = "core-prod"
   application_port  = 8080
@@ -92,6 +101,10 @@ module "database" {
 
 module "front_door" {
   source = "../modules/front_door"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   prefix                = local.prefix
   application_port      = local.application_port

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -26,6 +26,15 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
 locals {
   prefix            = "core-staging"
   application_port  = 8080
@@ -93,12 +102,15 @@ module "database" {
 module "front_door" {
   source = "../modules/front_door"
 
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
   prefix                = local.prefix
   application_port      = local.application_port
   ecs_security_group_id = module.application.ecs_security_group_id
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
-  provider_role_arn     = local.provider_role_arn
 }
 
 module "networking" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -22,15 +22,16 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::107155005276:role/developer"
+    role_arn = local.provider_role_arn
   }
 }
 
 locals {
-  prefix           = "core-staging"
-  application_port = 8080
-  database_port    = 5432
-  redis_port       = 6379
+  prefix            = "core-staging"
+  application_port  = 8080
+  database_port     = 5432
+  provider_role_arn = "arn:aws:iam::107155005276:role/developer"
+  redis_port        = 6379
 }
 
 module "application" {
@@ -97,6 +98,7 @@ module "front_door" {
   ecs_security_group_id = module.application.ecs_security_group_id
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
+  provider_role_arn     = local.provider_role_arn
 }
 
 module "networking" {


### PR DESCRIPTION
Setup WAF to cover our cloudfront distribution with the following AWS managed rules suggested on the ticket:
- `AWSManagedRulesCommonRuleSet` (excluding the `SizeRestrictions_BODY` rule to allow file uploads)
- `AWSManagedRulesKnownBadInputsRuleSet`
- `AWSManagedRulesAmazonIpReputationList`

I also added the following rule sets as they applied to our use case (as prompted by the ticket):
- `AWSManagedRulesSQLiRuleSet`
- `AWSManagedRulesLinuxRuleSet`
- `AWSManagedRulesUnixRuleSet`
See my comment on the rule priority order for more info about the rules and what they cover