### PR TITLE
Create certificates

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -36,11 +36,13 @@ provider "aws" {
 }
 
 locals {
-  prefix            = "core-dev"
-  application_port  = 8080
-  database_port     = 5432
-  provider_role_arn = "arn:aws:iam::837698168072:role/developer"
-  redis_port        = 6379
+  prefix                    = "core-dev"
+  app_host                  = ""
+  application_port          = 8080
+  database_port             = 5432
+  load_balancer_domain_name = ""
+  provider_role_arn         = "arn:aws:iam::837698168072:role/developer"
+  redis_port                = 6379
 }
 
 module "application" {
@@ -85,6 +87,17 @@ module "cds_export" {
   source = "../modules/cds_export"
 
   prefix = local.prefix
+}
+
+module "certificates" {
+  source = "../modules/certificates"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  cloudfront_domain_name    = local.app_host
+  load_balancer_domain_name = local.load_balancer_domain_name
 }
 
 module "database" {

--- a/terraform/development/outputs.tf
+++ b/terraform/development/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_certificate_validation" {
+  value       = module.certificates.cloudfront_certificate_validation
+  description = "The domain validation objects for the cloudfront certificate"
+}
+
+output "load_balancer_certificate_validation" {
+  value       = module.certificates.load_balancer_certificate_validation
+  description = "The domain validation objects for the load balancer certificate"
+}

--- a/terraform/modules/certificates/certificates.tf
+++ b/terraform/modules/certificates/certificates.tf
@@ -1,0 +1,17 @@
+resource "aws_acm_certificate" "cloudfront" {
+  domain_name       = var.cloudfront_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "load_balancer" {
+  domain_name       = var.load_balancer_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/modules/certificates/main.tf
+++ b/terraform/modules/certificates/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~>1.5.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}

--- a/terraform/modules/certificates/outputs.tf
+++ b/terraform/modules/certificates/outputs.tf
@@ -1,0 +1,19 @@
+output "cloudfront_certificate_arn" {
+  value       = aws_acm_certificate.cloudfront.arn
+  description = "The arn of the cloudfront certificate"
+}
+
+output "cloudfront_certificate_validation" {
+  value       = aws_acm_certificate.cloudfront.domain_validation_options
+  description = "The domain validation objects for the cloudfront certificate"
+}
+
+output "load_balancer_certificate_arn" {
+  value       = aws_acm_certificate.load_balancer.arn
+  description = "The arn of the load balancer certificate"
+}
+
+output "load_balancer_certificate_validation" {
+  value       = aws_acm_certificate.load_balancer.domain_validation_options
+  description = "The domain validation objects for the load balancer certificate"
+}

--- a/terraform/modules/certificates/variables.tf
+++ b/terraform/modules/certificates/variables.tf
@@ -1,0 +1,9 @@
+variable "cloudfront_domain_name" {
+  type        = string
+  description = "Then domain name of the cloudfront distribution"
+}
+
+variable "load_balancer_domain_name" {
+  type        = string
+  description = "Then domain name of the load balancer"
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -36,11 +36,13 @@ provider "aws" {
 }
 
 locals {
-  prefix            = "core-prod"
-  application_port  = 8080
-  database_port     = 5432
-  provider_role_arn = "arn:aws:iam::977287343304:role/developer"
-  redis_port        = 6379
+  prefix                    = "core-prod"
+  app_host                  = "submit-social-housing-data.levellingup.gov.uk"
+  application_port          = 8080
+  database_port             = 5432
+  load_balancer_domain_name = "lb.submit-social-housing-data.levellingup.gov.uk"
+  provider_role_arn         = "arn:aws:iam::977287343304:role/developer"
+  redis_port                = 6379
 }
 
 module "application" {
@@ -85,6 +87,17 @@ module "cds_export" {
   source = "../modules/cds_export"
 
   prefix = local.prefix
+}
+
+module "certificates" {
+  source = "../modules/certificates"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  cloudfront_domain_name    = local.app_host
+  load_balancer_domain_name = local.load_balancer_domain_name
 }
 
 module "database" {

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_certificate_validation" {
+  value       = module.certificates.cloudfront_certificate_validation
+  description = "The domain validation objects for the cloudfront certificate"
+}
+
+output "load_balancer_certificate_validation" {
+  value       = module.certificates.load_balancer_certificate_validation
+  description = "The domain validation objects for the load balancer certificate"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -36,11 +36,13 @@ provider "aws" {
 }
 
 locals {
-  prefix            = "core-staging"
-  application_port  = 8080
-  database_port     = 5432
-  provider_role_arn = "arn:aws:iam::107155005276:role/developer"
-  redis_port        = 6379
+  prefix                    = "core-staging"
+  app_host                  = "staging.submit-social-housing-data.levellingup.gov.uk"
+  application_port          = 8080
+  database_port             = 5432
+  load_balancer_domain_name = "staging.lb.submit-social-housing-data.levellingup.gov.uk"
+  provider_role_arn         = "arn:aws:iam::107155005276:role/developer"
+  redis_port                = 6379
 }
 
 module "application" {
@@ -85,6 +87,17 @@ module "cds_export" {
   source = "../modules/cds_export"
 
   prefix = local.prefix
+}
+
+module "certificates" {
+  source = "../modules/certificates"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  cloudfront_domain_name    = local.app_host
+  load_balancer_domain_name = local.load_balancer_domain_name
 }
 
 module "database" {

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_certificate_validation" {
+  value       = module.certificates.cloudfront_certificate_validation
+  description = "The domain validation objects for the cloudfront certificate"
+}
+
+output "load_balancer_certificate_validation" {
+  value       = module.certificates.load_balancer_certificate_validation
+  description = "The domain validation objects for the load balancer certificate"
+}


### PR DESCRIPTION
Create certificates, but don't update the front door module to use them yet!

This work is a replica of the relevant parts of the `certificates` branch. Here's the [PR](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/27/files#diff-fe008d85d2f075ffda7cea4a6fc9c8ed7b39b7970425b8cea73ab488a81df2f0) that undid all of the certificates work in one go (so it's easy to see all the changes). Alternatively in your IDE look at the diff between the `certificates` branch and commit `45f214b`.