### PR TITLE
CLDC-2764: add CDS role arns

### DIFF
--- a/terraform/modules/cds_export/role_cds.tf
+++ b/terraform/modules/cds_export/role_cds.tf
@@ -1,5 +1,5 @@
 locals {
-  create_cds_role = var.cds_access_role_arn != null
+  create_cds_role = var.cds_access_role_arns != null
 }
 
 data "aws_iam_policy_document" "cds_assume_role" {
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "cds_assume_role" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.cds_access_role_arn]
+      identifiers = var.cds_access_role_arns
     }
   }
 }

--- a/terraform/modules/cds_export/variables.tf
+++ b/terraform/modules/cds_export/variables.tf
@@ -1,7 +1,7 @@
-variable "cds_access_role_arn" {
-  type        = string
+variable "cds_access_role_arns" {
+  type        = list(string)
   default     = null
-  description = "The arn of the role the CDS team will use to assume a role we define"
+  description = "The arn's of the roles the CDS team will use to assume a role we define"
 }
 
 variable "prefix" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -85,6 +85,10 @@ module "cds_export" {
   source = "../modules/cds_export"
 
   prefix = local.prefix
+  cds_access_role_arns = [
+    "arn:aws:iam::062321884391:role/DSQL1",
+    "arn:aws:iam::062321884391:role/DSQSS"
+  ]
 }
 
 module "database" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -85,6 +85,10 @@ module "cds_export" {
   source = "../modules/cds_export"
 
   prefix = local.prefix
+  cds_access_role_arns = [
+    "arn:aws:iam::062321884391:role/DSQL1",
+    "arn:aws:iam::062321884391:role/DSQSS"
+  ]
 }
 
 module "database" {


### PR DESCRIPTION
- Update implementation to take multiple arns rather than one
- Hardcode the role ARNs given by CDS to enable access to our staging / prod export buckets
