### PR TITLE
Update front door with certificates work

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -120,14 +120,14 @@ module "front_door" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  prefix                = local.prefix
-  application_port      = local.application_port
-  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name = local.app_host
-  ecs_security_group_id = module.application.ecs_security_group_id
+  prefix                        = local.prefix
+  application_port              = local.application_port
+  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name        = local.app_host
+  ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  public_subnet_ids     = module.networking.public_subnet_ids
-  vpc_id                = module.networking.vpc_id
+  public_subnet_ids             = module.networking.public_subnet_ids
+  vpc_id                        = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -125,6 +125,7 @@ module "front_door" {
   cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
+  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -122,6 +122,8 @@ module "front_door" {
 
   prefix                = local.prefix
   application_port      = local.application_port
+  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -30,7 +30,7 @@ resource "aws_cloudfront_distribution" "this" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "http-only"
+      origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
 

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -16,6 +16,7 @@ resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV_AWS_174:TODO CLDC-2680
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
   #checkov:skip=CKV_AWS_310:we have decided that we're unlikely to need a secondary load balancer
+  aliases         = [var.cloudfront_domain_name]
   enabled         = true
   http_version    = "http2and3"
   is_ipv6_enabled = true
@@ -47,11 +48,13 @@ resource "aws_cloudfront_distribution" "this" {
     origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
     response_headers_policy_id = data.aws_cloudfront_response_headers_policy.this.id
     target_origin_id           = local.origin_id
-    viewer_protocol_policy     = "allow-all"
+    viewer_protocol_policy     = "redirect-to-https"
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = var.cloudfront_certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
   }
 
   restrictions {

--- a/terraform/modules/front_door/policies.tf
+++ b/terraform/modules/front_door/policies.tf
@@ -33,10 +33,7 @@ resource "aws_cloudfront_origin_request_policy" "this" {
   }
 
   headers_config {
-    header_behavior = "allExcept"
-    headers {
-      items = ["Origin"]
-    }
+    header_behavior = "allViewer"
   }
 
   query_strings_config {

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -3,6 +3,16 @@ variable "application_port" {
   description = "The network port the application runs on"
 }
 
+variable "cloudfront_certificate_arn" {
+  type        = string
+  description = "The arn of the certifcate to be associated with cloudfront"
+}
+
+variable "cloudfront_domain_name" {
+  type        = string
+  description = "Then domain name of the cloudfront distribution"
+}
+
 variable "ecs_security_group_id" {
   type        = string
   description = "The id of the ecs security group for ecs egress"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -18,6 +18,11 @@ variable "ecs_security_group_id" {
   description = "The id of the ecs security group for ecs egress"
 }
 
+variable "load_balancer_certificate_arn" {
+  type        = string
+  description = "The arn of the certifcate to be associated with the load balancer HTTPS listener"
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to be prepended to resource names."

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -120,14 +120,14 @@ module "front_door" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  prefix                = local.prefix
-  application_port      = local.application_port
-  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name = local.app_host
-  ecs_security_group_id = module.application.ecs_security_group_id
+  prefix                        = local.prefix
+  application_port              = local.application_port
+  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name        = local.app_host
+  ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  public_subnet_ids     = module.networking.public_subnet_ids
-  vpc_id                = module.networking.vpc_id
+  public_subnet_ids             = module.networking.public_subnet_ids
+  vpc_id                        = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -125,6 +125,7 @@ module "front_door" {
   cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
+  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -122,6 +122,8 @@ module "front_door" {
 
   prefix                = local.prefix
   application_port      = local.application_port
+  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -120,14 +120,14 @@ module "front_door" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  prefix                = local.prefix
-  application_port      = local.application_port
-  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name = local.app_host
-  ecs_security_group_id = module.application.ecs_security_group_id
+  prefix                        = local.prefix
+  application_port              = local.application_port
+  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name        = local.app_host
+  ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  public_subnet_ids     = module.networking.public_subnet_ids
-  vpc_id                = module.networking.vpc_id
+  public_subnet_ids             = module.networking.public_subnet_ids
+  vpc_id                        = module.networking.vpc_id
 }
 
 module "networking" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -125,6 +125,7 @@ module "front_door" {
   cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
+  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -122,6 +122,8 @@ module "front_door" {
 
   prefix                = local.prefix
   application_port      = local.application_port
+  cloudfront_certificate_arn = module.certificates.cloudfront_certificate_arn
+  cloudfront_domain_name = local.app_host
   ecs_security_group_id = module.application.ecs_security_group_id
   public_subnet_ids     = module.networking.public_subnet_ids
   vpc_id                = module.networking.vpc_id


### PR DESCRIPTION
The remainder of the original certificates work: updating the front door module to use the certificates generated, as well as enforcing HTTPs etc.

See https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/27/files for all of the certificates work in one place (I have manually replicated this over 2 PRs - this one and also https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/42/files).

In this PR I have also undone the change to the cloudfront origin request policy that was made in https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/25/files (this was necessary only whilst waiting for the certificates work to be done).