### PR TITLE
Fix & improve load balancer + cloudfront

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -126,6 +126,7 @@ module "front_door" {
   cloudfront_domain_name        = local.app_host
   ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
+  load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
   vpc_id                        = module.networking.vpc_id
 }

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -24,7 +24,7 @@ resource "aws_cloudfront_distribution" "this" {
   web_acl_id      = aws_wafv2_web_acl.this.arn
 
   origin {
-    domain_name = aws_lb.this.dns_name
+    domain_name = var.load_balancer_domain_name
     origin_id   = local.origin_id
 
     custom_origin_config {

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -5,15 +5,10 @@ locals {
 
 #tfsec:ignore:aws-cloudfront-enable-logging:TODO we will be implementing logging later
 #tfsec:ignore:aws-cloudfront-enable-waf:TODO CLDC-2546
-#tfsec:ignore:aws-cloudfront-enforce-https:TODO CLDC-2654
-#tfsec:ignore:aws-cloudfront-use-secure-tls-policy:TODO CLDC-2680
 resource "aws_cloudfront_distribution" "this" {
-  #checkov:skip=CKV_AWS_34:TODO CLDC-2654
-  #checkov:skip=CKV2_AWS_42:TODO CLDC-2680
   #checkov:skip=CKV2_AWS_47:TODO CLDC-2546 when setting up WAF it should be configured appropriately to mitigate against the Log4j vulnerability https://docs.bridgecrew.io/docs/ensure-aws-cloudfront-attached-wafv2-webacl-is-configured-with-amr-for-log4j-vulnerability
   #checkov:skip=CKV_AWS_68:TODO CLDC-2546
   #checkov:skip=CKV_AWS_86:TODO we will be implementing logging later
-  #checkov:skip=CKV_AWS_174:TODO CLDC-2680
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
   #checkov:skip=CKV_AWS_310:we have decided that we're unlikely to need a secondary load balancer
   aliases         = [var.cloudfront_domain_name]

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -1,4 +1,3 @@
-#tfsec:ignore:aws-elb-alb-not-public:load balancer is exposed to internet as it receives traffic from public
 resource "aws_lb" "this" {
   #checkov:skip=CKV_AWS_91:setup access logs on load balancer TODO CLDC-2705
   #checkov:skip=CKV2_AWS_28:WAF protection to be setup TODO CLDC-2546

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -14,14 +14,14 @@ resource "aws_lb" "this" {
 resource "aws_lb_target_group" "this" {
   name        = var.prefix
   port        = var.application_port
-  protocol    = "HTTPS"
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
 
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    protocol            = "HTTPS"
+    protocol            = "HTTP"
     matcher             = "204"
     timeout             = "3"
     path                = "/health"

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -1,3 +1,4 @@
+#tfsec:ignore:aws-elb-alb-not-public:the load balancer must be exposed to the internet in order to communicate with cloudfront
 resource "aws_lb" "this" {
   #checkov:skip=CKV_AWS_91:setup access logs on load balancer TODO CLDC-2705
   #checkov:skip=CKV2_AWS_28:WAF protection to be setup TODO CLDC-2546

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -8,16 +8,6 @@ resource "aws_security_group" "load_balancer" {
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "load_balancer_http_ingress" {
-  #checkov:skip=CKV_AWS_260:ingress from all IPs to port 80 required as load balancer is public
-  description       = "Allow http ingress from all IP addresses"
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "tcp"
-  from_port         = 80
-  to_port           = 80
-  security_group_id = aws_security_group.load_balancer.id
-}
-
 resource "aws_vpc_security_group_ingress_rule" "load_balancer_https_ingress" {
   description       = "Allow https ingress from all IP addresses"
   cidr_ipv4         = "0.0.0.0/0"

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "load_balancer" {
 }
 
 data "aws_ec2_managed_prefix_list" "cloudfront" {
- name = "com.amazonaws.global.cloudfront.origin-facing"
+  name = "com.amazonaws.global.cloudfront.origin-facing"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "load_balancer_https_ingress" {

--- a/terraform/modules/front_door/security_groups.tf
+++ b/terraform/modules/front_door/security_groups.tf
@@ -8,12 +8,16 @@ resource "aws_security_group" "load_balancer" {
   }
 }
 
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+ name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
 resource "aws_vpc_security_group_ingress_rule" "load_balancer_https_ingress" {
-  description       = "Allow https ingress from all IP addresses"
-  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow https ingress from cloudfront only"
   ip_protocol       = "tcp"
   from_port         = 443
   to_port           = 443
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.cloudfront.id
   security_group_id = aws_security_group.load_balancer.id
 }
 

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -23,6 +23,11 @@ variable "load_balancer_certificate_arn" {
   description = "The arn of the certifcate to be associated with the load balancer HTTPS listener"
 }
 
+variable "load_balancer_domain_name" {
+  type        = string
+  description = "Then domain name of the load balancer"
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to be prepended to resource names."

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -130,6 +130,7 @@ module "front_door" {
   cloudfront_domain_name        = local.app_host
   ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
+  load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
   vpc_id                        = module.networking.vpc_id
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -130,6 +130,7 @@ module "front_door" {
   cloudfront_domain_name        = local.app_host
   ecs_security_group_id         = module.application.ecs_security_group_id
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
+  load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
   vpc_id                        = module.networking.vpc_id
 }


### PR DESCRIPTION
Final edits necessary to get all the front door stuff working + more secure:
- Use http, not https, between load balancer and application
- Remove obsolete checkov and tfsec ignores
- Restrict the load balancer ingress to only accept https traffic from cloudfront

Will `fmt` once everything else has been finalised.