### PR TITLE
Fix RDS alarms

### DIFF
--- a/terraform/modules/rds/alarms.tf
+++ b/terraform/modules/rds/alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
   insufficient_data_actions = []
 
   dimensions = {
-    DBInstanceIdentifier = aws_db_instance.this.id
+    DBInstanceIdentifier = aws_db_instance.this.identifier
   }
 }
 
@@ -32,6 +32,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
   insufficient_data_actions = []
 
   dimensions = {
-    DBInstanceIdentifier = aws_db_instance.this.id
+    DBInstanceIdentifier = aws_db_instance.this.identifier
   }
 }


### PR DESCRIPTION
I found that the RDS alarms I created were in a state of 'insufficient data'. It's because I'd used `aws_db_instance.this.id` rather than `aws_db_instance.this.identifier` in Terraform (the the latter is the name of the db instance, which is what we want). I've updated this and now the alarms in cloudwatch look good 👍