### PR TITLE
CLDC-2785: App running tasks alarm

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -38,6 +38,7 @@ provider "aws" {
 locals {
   prefix                    = "core-dev"
   app_host                  = ""
+  app_task_desired_count    = 2
   application_port          = 8080
   database_port             = 5432
   load_balancer_domain_name = ""
@@ -51,7 +52,7 @@ module "application" {
   prefix                               = local.prefix
   app_host                             = ""
   app_task_cpu                         = 512
-  app_task_desired_count               = 2
+  app_task_desired_count               = local.app_task_desired_count
   app_task_memory                      = 1024
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
@@ -123,6 +124,7 @@ module "front_door" {
   }
 
   prefix                        = local.prefix
+  app_task_desired_count        = local.app_task_desired_count
   application_port              = local.application_port
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name        = local.app_host

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -130,6 +130,7 @@ module "front_door" {
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
+  sns_topic_arn                 = module.monitoring.sns_topic_arn
   vpc_id                        = module.networking.vpc_id
 }
 

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
   ok_actions                = [var.sns_topic_arn]
-  period                    = 8 * 60
+  period                    = 8 * 60 # By causing the app to fail repeatedly (with both 2 tasks and 4 tasks running) I found that double the desired count would reliably fail in an 8 minute period.
   statistic                 = "Sum"
   threshold                 = 2 * var.app_task_desired_count
   insufficient_data_actions = []

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -38,6 +38,25 @@ resource "aws_cloudwatch_metric_alarm" "app_memory" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
+  alarm_actions             = [var.sns_topic_arn]
+  alarm_name                = "${var.prefix}-app-tasks-exited"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm       = 2 * var.app_task_desired_count
+  evaluation_periods        = 8
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  ok_actions                = [var.sns_topic_arn]
+  period                    = 60
+  statistic                 = "Sum"
+  threshold                 = 1
+  insufficient_data_actions = []
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.app_task_exited.name
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "sidekiq_cpu" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-sidekiq-cpu"

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -42,14 +42,14 @@ resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-app-tasks-exited"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  datapoints_to_alarm       = 2 * var.app_task_desired_count
-  evaluation_periods        = 8
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
   ok_actions                = [var.sns_topic_arn]
-  period                    = 60
+  period                    = 8 * 60
   statistic                 = "Sum"
-  threshold                 = 1
+  threshold                 = 2 * var.app_task_desired_count
   insufficient_data_actions = []
 
   dimensions = {

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -57,6 +57,25 @@ resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "app_service_action_problem" {
+  alarm_actions             = [var.sns_topic_arn]
+  alarm_name                = "${var.prefix}-app-service-action-problem"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  ok_actions                = [var.sns_topic_arn]
+  period                    = 60
+  statistic                 = "Sum"
+  threshold                 = 1
+  insufficient_data_actions = []
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.app_service_action_problem.name
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "sidekiq_cpu" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-sidekiq-cpu"

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -20,3 +20,24 @@ resource "aws_cloudwatch_event_rule" "app_task_exited" {
     }
   )
 }
+
+resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
+  name        = "${var.prefix}-app-service-action-problem"
+
+  event_pattern = jsonencode(
+    {
+        "source": [
+            "aws.ecs"
+        ],
+        "detail-type": [
+            "ECS Service Action"
+        ],
+        "resources": [
+            "${aws_ecs_service.app.name}"
+        ],
+        "detail": {
+            "eventType": ["WARN", "ERROR"]
+        }
+    }
+  )
+}

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -24,6 +24,7 @@ resource "aws_cloudwatch_event_rule" "app_task_exited" {
 resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
   name = "${var.prefix}-app-service-action-problem"
 
+  # This event pattern was used based on the answer here: https://serverfault.com/questions/1012603/create-a-cloudwatch-alarm-when-an-ecs-service-unable-to-consistently-start-tasks.
   event_pattern = jsonencode(
     {
       "source" : [

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -19,5 +19,4 @@ resource "aws_cloudwatch_event_rule" "app_task_exited" {
         }
     }
   )
-
 }

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -1,0 +1,23 @@
+resource "aws_cloudwatch_event_rule" "app_task_exited" {
+  name        = "${var.prefix}-app-task-exited"
+
+  event_pattern = jsonencode(
+    {
+        "source": [
+            "aws.ecs"
+        ],
+        "detail-type": [
+            "ECS Task State Change"
+        ],
+        "detail": {
+            "group": [
+                "service:${aws_ecs_service.app.name}"
+            ],
+            "stoppedReason": [
+                "Essential container in task exited"
+            ]
+        }
+    }
+  )
+
+}

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
         "ECS Service Action"
       ],
       "resources" : [
-        aws_ecs_service.app.arn
+        aws_ecs_service.app.id
       ],
       "detail" : {
         "eventType" : ["WARN", "ERROR"]

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -1,43 +1,43 @@
 resource "aws_cloudwatch_event_rule" "app_task_exited" {
-  name        = "${var.prefix}-app-task-exited"
+  name = "${var.prefix}-app-task-exited"
 
   event_pattern = jsonencode(
     {
-        "source": [
-            "aws.ecs"
+      "source" : [
+        "aws.ecs"
+      ],
+      "detail-type" : [
+        "ECS Task State Change"
+      ],
+      "detail" : {
+        "group" : [
+          "service:${aws_ecs_service.app.name}"
         ],
-        "detail-type": [
-            "ECS Task State Change"
-        ],
-        "detail": {
-            "group": [
-                "service:${aws_ecs_service.app.name}"
-            ],
-            "stoppedReason": [
-                "Essential container in task exited"
-            ]
-        }
+        "stoppedReason" : [
+          "Essential container in task exited"
+        ]
+      }
     }
   )
 }
 
 resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
-  name        = "${var.prefix}-app-service-action-problem"
+  name = "${var.prefix}-app-service-action-problem"
 
   event_pattern = jsonencode(
     {
-        "source": [
-            "aws.ecs"
-        ],
-        "detail-type": [
-            "ECS Service Action"
-        ],
-        "resources": [
-            aws_ecs_service.app.name
-        ],
-        "detail": {
-            "eventType": ["WARN", "ERROR"]
-        }
+      "source" : [
+        "aws.ecs"
+      ],
+      "detail-type" : [
+        "ECS Service Action"
+      ],
+      "resources" : [
+        aws_ecs_service.app.name
+      ],
+      "detail" : {
+        "eventType" : ["WARN", "ERROR"]
+      }
     }
   )
 }

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
             "ECS Service Action"
         ],
         "resources": [
-            "${aws_ecs_service.app.name}"
+            aws_ecs_service.app.name
         ],
         "detail": {
             "eventType": ["WARN", "ERROR"]

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
         "ECS Service Action"
       ],
       "resources" : [
-        aws_ecs_service.app.name
+        aws_ecs_service.app.arn
       ],
       "detail" : {
         "eventType" : ["WARN", "ERROR"]

--- a/terraform/modules/front_door/alarms.tf
+++ b/terraform/modules/front_door/alarms.tf
@@ -1,3 +1,23 @@
+resource "aws_cloudwatch_metric_alarm" "healthy_hosts_count" {
+  alarm_actions             = [var.sns_topic_arn]
+  alarm_name                = "${var.prefix}-healthy-hosts-count"
+  comparison_operator       = "LessThanThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
+  metric_name               = "HealthyHostCount"
+  namespace                 = "AWS/ApplicationELB"
+  ok_actions                = [var.sns_topic_arn]
+  period                    = 60
+  statistic                 = "Minimum"
+  threshold                 = var.app_task_desired_count
+  insufficient_data_actions = []
+
+  dimensions = {
+    LoadBalancer = aws_lb.this.arn_suffix
+    TargetGroup  = aws_lb_target_group.this.arn_suffix
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_count" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-unhealthy-hosts-count"

--- a/terraform/modules/front_door/alarms.tf
+++ b/terraform/modules/front_door/alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_count" {
   insufficient_data_actions = []
 
   dimensions = {
-    LoadBalancer = aws_lb.this.name
-    TargetGroup  = aws_lb_target_group.this.name
+    LoadBalancer = aws_lb.this.arn_suffix
+    TargetGroup  = aws_lb_target_group.this.arn_suffix
   }
 }

--- a/terraform/modules/front_door/alarms.tf
+++ b/terraform/modules/front_door/alarms.tf
@@ -1,0 +1,19 @@
+resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_count" {
+  alarm_actions             = [var.sns_topic_arn]
+  alarm_name                = "${var.prefix}-unhealthy-hosts-count"
+  comparison_operator       = "GreaterThanThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
+  metric_name               = "UnHealthyHostCount"
+  namespace                 = "AWS/ApplicationELB"
+  ok_actions                = [var.sns_topic_arn]
+  period                    = 60
+  statistic                 = "Maximum"
+  threshold                 = 0
+  insufficient_data_actions = []
+
+  dimensions = {
+    LoadBalancer = aws_lb.this.name
+    TargetGroup  = aws_lb_target_group.this.name
+  }
+}

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -14,14 +14,14 @@ resource "aws_lb" "this" {
 resource "aws_lb_target_group" "this" {
   name        = var.prefix
   port        = var.application_port
-  protocol    = "HTTP"
+  protocol    = "HTTPS"
   vpc_id      = var.vpc_id
   target_type = "ip"
 
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    protocol            = "HTTP"
+    protocol            = "HTTPS"
     matcher             = "204"
     timeout             = "3"
     path                = "/health"

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -14,14 +14,14 @@ resource "aws_lb" "this" {
 resource "aws_lb_target_group" "this" {
   name        = var.prefix
   port        = var.application_port
-  protocol    = "HTTPS"
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
 
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    protocol            = "HTTPS"
+    protocol            = "HTTP"
     matcher             = "204"
     timeout             = "3"
     path                = "/health"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -1,3 +1,8 @@
+variable "app_task_desired_count" {
+  type        = number
+  description = "The number of instances of the ecs app task definition desired"
+}
+
 variable "application_port" {
   type        = number
   description = "The network port the application runs on"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -38,6 +38,11 @@ variable "public_subnet_ids" {
   description = "The ids of all the public subnets"
 }
 
+variable "sns_topic_arn" {
+  type        = string
+  description = "The arn of the sns topic"
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the VPC to be associated with."

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -38,6 +38,7 @@ provider "aws" {
 locals {
   prefix                    = "core-prod"
   app_host                  = "submit-social-housing-data.levellingup.gov.uk"
+  app_task_desired_count    = 2
   application_port          = 8080
   database_port             = 5432
   load_balancer_domain_name = "lb.submit-social-housing-data.levellingup.gov.uk"
@@ -51,7 +52,7 @@ module "application" {
   prefix                               = local.prefix
   app_host                             = ""
   app_task_cpu                         = 512
-  app_task_desired_count               = 2
+  app_task_desired_count               = local.app_task_desired_count
   app_task_memory                      = 1024
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
@@ -127,6 +128,7 @@ module "front_door" {
   }
 
   prefix                        = local.prefix
+  app_task_desired_count        = local.app_task_desired_count
   application_port              = local.application_port
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name        = local.app_host

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -134,6 +134,7 @@ module "front_door" {
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
+  sns_topic_arn                 = module.monitoring.sns_topic_arn
   vpc_id                        = module.networking.vpc_id
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -51,7 +51,7 @@ module "application" {
   prefix                               = local.prefix
   app_host                             = ""
   app_task_cpu                         = 512
-  app_task_desired_count               = 4
+  app_task_desired_count               = 2
   app_task_memory                      = 1024
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -38,6 +38,7 @@ provider "aws" {
 locals {
   prefix                    = "core-staging"
   app_host                  = "staging.submit-social-housing-data.levellingup.gov.uk"
+  app_task_desired_count    = 2
   application_port          = 8080
   database_port             = 5432
   load_balancer_domain_name = "staging.lb.submit-social-housing-data.levellingup.gov.uk"
@@ -51,7 +52,7 @@ module "application" {
   prefix                               = local.prefix
   app_host                             = ""
   app_task_cpu                         = 512
-  app_task_desired_count               = 2
+  app_task_desired_count               = local.app_task_desired_count
   app_task_memory                      = 1024
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn
@@ -127,6 +128,7 @@ module "front_door" {
   }
 
   prefix                        = local.prefix
+  app_task_desired_count        = local.app_task_desired_count
   application_port              = local.application_port
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   cloudfront_domain_name        = local.app_host

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -51,7 +51,7 @@ module "application" {
   prefix                               = local.prefix
   app_host                             = ""
   app_task_cpu                         = 512
-  app_task_desired_count               = 2
+  app_task_desired_count               = 4
   app_task_memory                      = 1024
   application_port                     = local.application_port
   bulk_upload_bucket_access_policy_arn = module.bulk_upload.read_write_policy_arn

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -134,6 +134,7 @@ module "front_door" {
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   load_balancer_domain_name     = local.load_balancer_domain_name
   public_subnet_ids             = module.networking.public_subnet_ids
+  sns_topic_arn                 = module.monitoring.sns_topic_arn
   vpc_id                        = module.networking.vpc_id
 }
 


### PR DESCRIPTION
As discussed, I've implemented:
- An alarm which looks for the "Essential container in task exited" event a certain number of times over a certain period
- An alarm which looks for any ECS Service Action issues (WARN or ERROR events)
- An alarm which checks for unhealthy hosts, and an alarm which checks whether the right number of healthy hosts