### PR TITLE
CLDC-2756: Make redis highly available

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -152,6 +152,7 @@ module "redis" {
 
   prefix                  = local.prefix
   ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = false
   node_type               = "cache.t4g.micro"
   redis_port              = local.redis_port
   redis_subnet_group_name = module.networking.redis_private_subnet_group_name

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_connection_string" {
-  value       = var.highly_available ? "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}:${var.redis_port}" : "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.cache_nodes[0].port}"
+  value       = var.highly_available ? "redis://${aws_elasticache_replication_group.this[0].primary_endpoint_address}:${var.redis_port}" : "redis://${aws_elasticache_cluster.this[0].cache_nodes[0].address}:${aws_elasticache_cluster.this[0].cache_nodes[0].port}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,9 @@
 output "redis_connection_string" {
-  value       = var.highly_available ? "redis://${aws_elasticache_replication_group.this[0].primary_endpoint_address}:${var.redis_port}" : "redis://${aws_elasticache_cluster.this[0].cache_nodes[0].address}:${aws_elasticache_cluster.this[0].cache_nodes[0].port}"
+  value = var.highly_available ? (
+    "redis://${aws_elasticache_replication_group.this[0].primary_endpoint_address}:${var.redis_port}"
+    ) : (
+    "redis://${aws_elasticache_cluster.this[0].cache_nodes[0].address}:${aws_elasticache_cluster.this[0].cache_nodes[0].port}"
+  )
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_connection_string" {
-  value       = "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}"
+  value       = "redis://${aws_elasticache_replication_group.this.reader_endpoint_address}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_connection_string" {
-  value       = "redis://${aws_elasticache_replication_group.this.reader_endpoint_address}"
+  value       = "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}:${var.redis_port}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_connection_string" {
-  value       = "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}:${var.redis_port}"
+  value       = var.highly_available ? "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}:${var.redis_port}" : "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.cache_nodes[0].port}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -1,5 +1,5 @@
 output "redis_connection_string" {
-  value       = "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:${aws_elasticache_cluster.this.cache_nodes[0].port}"
+  value       = "redis://${aws_elasticache_replication_group.this.primary_endpoint_address}"
   description = "A connection string for connecting to the primary redis node, intended to be set in the environment variable REDIS_CONFIG"
   sensitive   = true
 }

--- a/terraform/modules/elasticache/parameter_groups.tf
+++ b/terraform/modules/elasticache/parameter_groups.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticache_parameter_group" "this" {
   name = var.prefix
-  # Ensure the redis version below tallies with the engine_version defined for the redis elasticache replication group (see redis.tf)
+  # Ensure the redis version below tallies with the engine_version defined for the redis elasticache cluster/replication group (see redis.tf)
   # Parameter group families are outlined here - https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html
   family = "redis6.x"
 

--- a/terraform/modules/elasticache/parameter_groups.tf
+++ b/terraform/modules/elasticache/parameter_groups.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticache_parameter_group" "this" {
   name = var.prefix
-  # Ensure the redis version below tallies with the engine_version defined for the redis elasticache cluster (see redis.tf)
+  # Ensure the redis version below tallies with the engine_version defined for the redis elasticache replication group (see redis.tf)
   # Parameter group families are outlined here - https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html
   family = "redis6.x"
 

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -1,4 +1,8 @@
+#tfsec:ignore:aws-elasticache-enable-in-transit-encryption:TODO CLDC-2848 potentially introduce encryption in transit later
 resource "aws_elasticache_replication_group" "this" {
+  #checkov:skip=CKV_AWS_30:TODO CLDC-2848 potentially introduce encryption in transit later
+  #checkov:skip=CKV_AWS_31:TODO CLDC-2848 potentially introduce encryption in transit later
+  #checkov:skip=CKV_AWS_191:default encryption key is sufficient
   apply_immediately           = true
   at_rest_encryption_enabled  = true
   auto_minor_version_upgrade  = true

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -1,5 +1,6 @@
 resource "aws_elasticache_replication_group" "this" {
   apply_immediately           = true
+  at_rest_encryption_enabled  = true
   auto_minor_version_upgrade  = true
   automatic_failover_enabled  = true
   description                 = "Redis replication group, containing a primary node and a replica."

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -1,18 +1,21 @@
 #tfsec:ignore:aws-elasticache-enable-backup-retention:TODO CLDC-2679 setup a snapshot retention limit
-resource "aws_elasticache_cluster" "this" {
+resource "aws_elasticache_replication_group" "this" {
   #checkov:skip=CKV_AWS_134:TODO CLDC-2679 setup a snapshot retention limit
-  #TODO CLDC-2679 setup redis replicas with multi-az and automatic failover
   #TODO CLDC-2682 setup redis logging
-  cluster_id                 = var.prefix
-  auto_minor_version_upgrade = true
-  apply_immediately          = true
-  engine                     = "redis"
-  engine_version             = "6.2"
-  maintenance_window         = "sun:23:00-mon:01:30"
-  node_type                  = var.node_type
-  num_cache_nodes            = 1
-  parameter_group_name       = aws_elasticache_parameter_group.this.id
-  port                       = var.redis_port
-  security_group_ids         = [aws_security_group.this.id]
-  subnet_group_name          = var.redis_subnet_group_name
+  apply_immediately           = true
+  auto_minor_version_upgrade  = true
+  automatic_failover_enabled  = true
+  description                 = "Redis replication group, containing a primary node and a replica."
+  engine                      = "redis"
+  engine_version              = "6.2"
+  maintenance_window          = "sun:23:00-mon:01:30"
+  multi_az_enabled            = true
+  node_type                   = var.node_type
+  num_cache_clusters          = 2
+  parameter_group_name        = aws_elasticache_parameter_group.this.id
+  port                        = var.redis_port
+  preferred_cache_cluster_azs = ["eu-west-2", "eu-west-1"] # The first AZ in the list is where the primary node will be created. Replicas will be created in the following AZs.
+  replication_group_id        = var.prefix
+  security_group_ids          = [aws_security_group.this.id]
+  subnet_group_name           = var.redis_subnet_group_name
 }

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -11,7 +11,7 @@ resource "aws_elasticache_replication_group" "this" {
   num_cache_clusters          = 2
   parameter_group_name        = aws_elasticache_parameter_group.this.id
   port                        = var.redis_port
-  preferred_cache_cluster_azs = ["eu-west-2", "eu-west-1"] # The first AZ in the list is where the primary node will be created. Replicas will be created in the following AZs.
+  preferred_cache_cluster_azs = ["eu-west-2a", "eu-west-2b"] # The first AZ in the list is where the primary node will be created. Replicas will be created in the following AZs.
   replication_group_id        = var.prefix
   security_group_ids          = [aws_security_group.this.id]
   subnet_group_name           = var.redis_subnet_group_name

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -32,8 +32,8 @@ resource "aws_elasticache_cluster" "this" {
   count = var.highly_available ? 0 : 1
 
   cluster_id                 = var.prefix
-  auto_minor_version_upgrade = true
   apply_immediately          = true
+  auto_minor_version_upgrade = true
   engine                     = "redis"
   engine_version             = "6.2"
   maintenance_window         = "sun:23:00-mon:01:30"

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -1,7 +1,4 @@
-#tfsec:ignore:aws-elasticache-enable-backup-retention:TODO CLDC-2679 setup a snapshot retention limit
 resource "aws_elasticache_replication_group" "this" {
-  #checkov:skip=CKV_AWS_134:TODO CLDC-2679 setup a snapshot retention limit
-  #TODO CLDC-2682 setup redis logging
   apply_immediately           = true
   auto_minor_version_upgrade  = true
   automatic_failover_enabled  = true

--- a/terraform/modules/elasticache/variables.tf
+++ b/terraform/modules/elasticache/variables.tf
@@ -3,6 +3,11 @@ variable "ecs_security_group_id" {
   description = "The id of the ecs security group for ecs ingress"
 }
 
+variable "highly_available" {
+  type        = bool
+  description = "Whether or not to make redis highly available (whether to have replicas or not)."
+}
+
 variable "node_type" {
   type        = string
   description = "The type of node for the redis elasticache."

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -156,6 +156,7 @@ module "redis" {
 
   prefix                  = local.prefix
   ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = true
   node_type               = "cache.t4g.micro"
   redis_port              = local.redis_port
   redis_subnet_group_name = module.networking.redis_private_subnet_group_name

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -155,8 +155,8 @@ module "redis" {
   source = "../modules/elasticache"
 
   prefix                  = local.prefix
-  highly_available        = true
   ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = true
   node_type               = "cache.t4g.micro"
   redis_port              = local.redis_port
   redis_subnet_group_name = module.networking.redis_private_subnet_group_name

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -155,6 +155,7 @@ module "redis" {
   source = "../modules/elasticache"
 
   prefix                  = local.prefix
+  highly_available        = true
   ecs_security_group_id   = module.application.ecs_security_group_id
   node_type               = "cache.t4g.micro"
   redis_port              = local.redis_port


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/CLDC-2756

Creating a highly-available (HA) setup with one primary and one replica node is most easily achieved by getting rid of the `aws_elasticache_cluster` resource entirely and using a `aws_elasticache_replication_group` resource instead. However we only want HA for some environments (prod and maybe staging), so I used a flag (at the redis module entrypoint) which is used in `count` expressions in the module to determine which of the resources gets created.

For now I've left staging with a HA setup in case whoever's reviewing this wants to test the failover. I can revert this to non-HA if needed though (the apply may take up to 30 minutes though - seems to take a long time to destroy and recreate these redis resources).

In terms of testing failover:
- This can be done by finding the cluster in the AWS console, selecting the primary node, and then clicking 'Failover primary' (I followed the instructions [here](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html#auto-failover-test) - in particular note that "During the failover process, the console continues to show the node's status as available. To track the progress of your failover test, choose Events from the console navigation pane.")
- When I did this:
  - The app seemed to continue working fine (I was clicking around in it)
  - I checked the app logs and didn't see anything related to the failover
  - I checked the sidekiq logs and saw some connection errors, and then saw messages like this "Redis is online, 35.something sec downtime" (these messages seem to be gone from the logs now, which is weird, but I definitely saw them!)
  - I'm assuming that's a successful failover, but shout if you disagree