### PR TITLE
CLDC-2755: Make DB highly available

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -105,16 +105,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                    = local.prefix
-  allocated_storage         = 5
-  backup_retention_period   = 7
-  db_subnet_group_name      = module.networking.db_private_subnet_group_name
-  database_port             = local.database_port
-  ecs_security_group_id     = module.application.ecs_security_group_id
-  highly_available          = false
-  instance_class            = "db.t3.micro"
-  sns_topic_arn             = module.monitoring.sns_topic_arn
-  vpc_id                    = module.networking.vpc_id
+  prefix                  = local.prefix
+  allocated_storage       = 5
+  backup_retention_period = 7
+  db_subnet_group_name    = module.networking.db_private_subnet_group_name
+  database_port           = local.database_port
+  ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = false
+  instance_class          = "db.t3.micro"
+  sns_topic_arn           = module.monitoring.sns_topic_arn
+  vpc_id                  = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -40,6 +40,7 @@ locals {
   app_host                  = ""
   app_task_desired_count    = 2
   application_port          = 8080
+  create_replica_standby_db = false
   database_port             = 5432
   load_balancer_domain_name = ""
   provider_role_arn         = "arn:aws:iam::837698168072:role/developer"
@@ -105,15 +106,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                  = local.prefix
-  allocated_storage       = 5
-  backup_retention_period = 7
-  db_subnet_group_name    = module.networking.db_private_subnet_group_name
-  database_port           = local.database_port
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  instance_class          = "db.t3.micro"
-  sns_topic_arn           = module.monitoring.sns_topic_arn
-  vpc_id                  = module.networking.vpc_id
+  prefix                    = local.prefix
+  allocated_storage         = 5
+  backup_retention_period   = 7
+  create_replica_standby_db = local.create_replica_standby_db
+  db_subnet_group_name      = module.networking.db_private_subnet_group_name
+  database_port             = local.database_port
+  ecs_security_group_id     = module.application.ecs_security_group_id
+  instance_class            = "db.t3.micro"
+  sns_topic_arn             = module.monitoring.sns_topic_arn
+  vpc_id                    = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -40,7 +40,6 @@ locals {
   app_host                  = ""
   app_task_desired_count    = 2
   application_port          = 8080
-  create_replica_standby_db = false
   database_port             = 5432
   load_balancer_domain_name = ""
   provider_role_arn         = "arn:aws:iam::837698168072:role/developer"
@@ -109,7 +108,6 @@ module "database" {
   prefix                    = local.prefix
   allocated_storage         = 5
   backup_retention_period   = 7
-  create_replica_standby_db = local.create_replica_standby_db
   db_subnet_group_name      = module.networking.db_private_subnet_group_name
   database_port             = local.database_port
   ecs_security_group_id     = module.application.ecs_security_group_id

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -113,6 +113,7 @@ module "database" {
   db_subnet_group_name      = module.networking.db_private_subnet_group_name
   database_port             = local.database_port
   ecs_security_group_id     = module.application.ecs_security_group_id
+  highly_available          = false
   instance_class            = "db.t3.micro"
   sns_topic_arn             = module.monitoring.sns_topic_arn
   vpc_id                    = module.networking.vpc_id

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -49,14 +49,13 @@ resource "aws_db_instance" "replica" {
   #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
   count               = var.create_replica_standby_db ? 1 : 0
   identifier          = "${var.prefix}-replica"
-  replicate_source_db = aws_db_instance.this.arn
+  replicate_source_db = aws_db_instance.this.identifier
 
   apply_immediately          = aws_db_instance.this.apply_immediately
   auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
   db_subnet_group_name       = aws_db_instance.this.db_subnet_group_name
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
-  deletion_protection        = true # needs to be set to false and applied if you need to delete the DB
   final_snapshot_identifier  = aws_db_instance.this.final_snapshot_identifier
   instance_class             = aws_db_instance.this.instance_class
   maintenance_window         = aws_db_instance.this.maintenance_window

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -38,6 +38,41 @@ resource "aws_db_instance" "this" {
   }
 }
 
+#tfsec:ignore:aws-rds-enable-performance-insights:TODO CLDC-2660 if necessary
+#tfsec:ignore:AVD-AWS-0176:iam authentication not suitable as tokens only last 15minutes, password authentication preferred
+resource "aws_db_instance" "replica" {
+  #checkov:skip=CKV_AWS_129:cloudwatch logs TODO CLDC-2660
+  #checkov:skip=CKV_AWS_118:monitoring TODO CLDC-2660
+  #checkov:skip=CKV_AWS_161:iam authentication not suitable as tokens only last 15minutes, password authentication preferred
+  #checkov:skip=CKV_AWS_353:performance insights TODO CLDC-2660 if necessary
+  #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
+  #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
+  count               = var.create_replica_standby_db ? 1 : 0
+  identifier          = "${var.prefix}-replica"
+  replicate_source_db = aws_db_instance.this.arn
+
+  apply_immediately          = aws_db_instance.this.apply_immediately
+  auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
+  copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
+  db_subnet_group_name       = aws_db_instance.this.db_subnet_group_name
+  delete_automated_backups   = aws_db_instance.this.delete_automated_backups
+  deletion_protection        = true # needs to be set to false and applied if you need to delete the DB
+  final_snapshot_identifier  = aws_db_instance.this.final_snapshot_identifier
+  instance_class             = aws_db_instance.this.instance_class
+  maintenance_window         = aws_db_instance.this.maintenance_window
+  multi_az                   = aws_db_instance.this.multi_az
+  port                       = aws_db_instance.this.port
+  publicly_accessible        = aws_db_instance.this.publicly_accessible
+  skip_final_snapshot        = aws_db_instance.this.skip_final_snapshot
+  storage_encrypted          = aws_db_instance.this.storage_encrypted
+  storage_type               = aws_db_instance.this.storage_type
+  vpc_security_group_ids     = aws_db_instance.this.vpc_security_group_ids
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_ssm_parameter" "database_connection_string" {
   #checkov:skip=CKV_AWS_337:default encryption not using a kms cmk sufficient
   name  = "DATA_COLLECTOR_DATABASE_URL"

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -47,14 +47,12 @@ resource "aws_db_instance" "replica" {
   #checkov:skip=CKV_AWS_353:performance insights TODO CLDC-2660 if necessary
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
   #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
-  count               = var.create_replica_standby_db ? 1 : 0
-  identifier          = "${var.prefix}-replica"
-  replicate_source_db = aws_db_instance.this.identifier
+  count = var.create_replica_standby_db ? 1 : 0
 
+  identifier                 = "${var.prefix}-replica"
   apply_immediately          = aws_db_instance.this.apply_immediately
   auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
-  db_subnet_group_name       = aws_db_instance.this.db_subnet_group_name
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
   final_snapshot_identifier  = aws_db_instance.this.final_snapshot_identifier
   instance_class             = aws_db_instance.this.instance_class
@@ -62,6 +60,7 @@ resource "aws_db_instance" "replica" {
   multi_az                   = aws_db_instance.this.multi_az
   port                       = aws_db_instance.this.port
   publicly_accessible        = aws_db_instance.this.publicly_accessible
+  replicate_source_db        = aws_db_instance.this.identifier
   skip_final_snapshot        = aws_db_instance.this.skip_final_snapshot
   storage_encrypted          = aws_db_instance.this.storage_encrypted
   storage_type               = aws_db_instance.this.storage_type

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -44,7 +44,7 @@ resource "aws_db_instance" "replica" {
   #checkov:skip=CKV_AWS_118:monitoring TODO CLDC-2660
   #checkov:skip=CKV_AWS_353:performance insights TODO CLDC-2660 if necessary
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
-  count = var.create_replica_standby_db ? 1 : 0
+  count = var.highly_available ? 1 : 0
 
   identifier                 = "${var.prefix}-replica"
   apply_immediately          = aws_db_instance.this.apply_immediately

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -39,14 +39,11 @@ resource "aws_db_instance" "this" {
 }
 
 #tfsec:ignore:aws-rds-enable-performance-insights:TODO CLDC-2660 if necessary
-#tfsec:ignore:AVD-AWS-0176:iam authentication not suitable as tokens only last 15minutes, password authentication preferred
 resource "aws_db_instance" "replica" {
   #checkov:skip=CKV_AWS_129:cloudwatch logs TODO CLDC-2660
   #checkov:skip=CKV_AWS_118:monitoring TODO CLDC-2660
-  #checkov:skip=CKV_AWS_161:iam authentication not suitable as tokens only last 15minutes, password authentication preferred
   #checkov:skip=CKV_AWS_353:performance insights TODO CLDC-2660 if necessary
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
-  #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
   count = var.create_replica_standby_db ? 1 : 0
 
   identifier                 = "${var.prefix}-replica"

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -54,6 +54,7 @@ resource "aws_db_instance" "replica" {
   auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
+  deletion_protection        = true
   final_snapshot_identifier  = aws_db_instance.this.final_snapshot_identifier
   instance_class             = aws_db_instance.this.instance_class
   maintenance_window         = aws_db_instance.this.maintenance_window

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -3,6 +3,11 @@ variable "allocated_storage" {
   description = "The allocated DB storage in gibibytes."
 }
 
+variable "create_replica_standby_db" {
+  type        = bool
+  description = "Flag for whether a replica standy DB should be made in case the main DB fails"
+}
+
 variable "database_port" {
   type        = number
   description = "The network port the database runs on"

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -3,11 +3,6 @@ variable "allocated_storage" {
   description = "The allocated DB storage in gibibytes."
 }
 
-variable "create_replica_standby_db" {
-  type        = bool
-  description = "Flag for whether a replica standy DB should be made in case the main DB fails"
-}
-
 variable "database_port" {
   type        = number
   description = "The network port the database runs on"
@@ -21,6 +16,11 @@ variable "db_subnet_group_name" {
 variable "ecs_security_group_id" {
   type        = string
   description = "The id of the ecs security group for ecs ingress"
+}
+
+variable "highly_available" {
+  type        = bool
+  description = "Whether or not to make the db highly available (whether to have replicas or not)."
 }
 
 variable "instance_class" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -40,6 +40,7 @@ locals {
   app_host                  = "submit-social-housing-data.levellingup.gov.uk"
   app_task_desired_count    = 2
   application_port          = 8080
+  create_replica_standby_db = true
   database_port             = 5432
   load_balancer_domain_name = "lb.submit-social-housing-data.levellingup.gov.uk"
   provider_role_arn         = "arn:aws:iam::977287343304:role/developer"
@@ -109,15 +110,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                  = local.prefix
-  allocated_storage       = 100
-  backup_retention_period = 7
-  database_port           = local.database_port
-  db_subnet_group_name    = module.networking.db_private_subnet_group_name
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  instance_class          = "db.t3.small"
-  sns_topic_arn           = module.monitoring.sns_topic_arn
-  vpc_id                  = module.networking.vpc_id
+  prefix                    = local.prefix
+  allocated_storage         = 100
+  backup_retention_period   = 7
+  create_replica_standby_db = local.create_replica_standby_db
+  database_port             = local.database_port
+  db_subnet_group_name      = module.networking.db_private_subnet_group_name
+  ecs_security_group_id     = module.application.ecs_security_group_id
+  instance_class            = "db.t3.small"
+  sns_topic_arn             = module.monitoring.sns_topic_arn
+  vpc_id                    = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -109,16 +109,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                    = local.prefix
-  allocated_storage         = 100
-  backup_retention_period   = 7
-  database_port             = local.database_port
-  db_subnet_group_name      = module.networking.db_private_subnet_group_name
-  ecs_security_group_id     = module.application.ecs_security_group_id
-  highly_available          = true
-  instance_class            = "db.t3.small"
-  sns_topic_arn             = module.monitoring.sns_topic_arn
-  vpc_id                    = module.networking.vpc_id
+  prefix                  = local.prefix
+  allocated_storage       = 100
+  backup_retention_period = 7
+  database_port           = local.database_port
+  db_subnet_group_name    = module.networking.db_private_subnet_group_name
+  ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = true
+  instance_class          = "db.t3.small"
+  sns_topic_arn           = module.monitoring.sns_topic_arn
+  vpc_id                  = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -40,7 +40,6 @@ locals {
   app_host                  = "submit-social-housing-data.levellingup.gov.uk"
   app_task_desired_count    = 2
   application_port          = 8080
-  create_replica_standby_db = true
   database_port             = 5432
   load_balancer_domain_name = "lb.submit-social-housing-data.levellingup.gov.uk"
   provider_role_arn         = "arn:aws:iam::977287343304:role/developer"
@@ -113,10 +112,10 @@ module "database" {
   prefix                    = local.prefix
   allocated_storage         = 100
   backup_retention_period   = 7
-  create_replica_standby_db = local.create_replica_standby_db
   database_port             = local.database_port
   db_subnet_group_name      = module.networking.db_private_subnet_group_name
   ecs_security_group_id     = module.application.ecs_security_group_id
+  highly_available          = true
   instance_class            = "db.t3.small"
   sns_topic_arn             = module.monitoring.sns_topic_arn
   vpc_id                    = module.networking.vpc_id

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -109,16 +109,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                    = local.prefix
-  allocated_storage         = 25
-  backup_retention_period   = 7
-  database_port             = local.database_port
-  db_subnet_group_name      = module.networking.db_private_subnet_group_name
-  ecs_security_group_id     = module.application.ecs_security_group_id
-  highly_available          = true
-  instance_class            = "db.t3.micro"
-  sns_topic_arn             = module.monitoring.sns_topic_arn
-  vpc_id                    = module.networking.vpc_id
+  prefix                  = local.prefix
+  allocated_storage       = 25
+  backup_retention_period = 7
+  database_port           = local.database_port
+  db_subnet_group_name    = module.networking.db_private_subnet_group_name
+  ecs_security_group_id   = module.application.ecs_security_group_id
+  highly_available        = true
+  instance_class          = "db.t3.micro"
+  sns_topic_arn           = module.monitoring.sns_topic_arn
+  vpc_id                  = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -115,7 +115,7 @@ module "database" {
   database_port           = local.database_port
   db_subnet_group_name    = module.networking.db_private_subnet_group_name
   ecs_security_group_id   = module.application.ecs_security_group_id
-  highly_available        = true
+  highly_available        = false
   instance_class          = "db.t3.micro"
   sns_topic_arn           = module.monitoring.sns_topic_arn
   vpc_id                  = module.networking.vpc_id

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -40,6 +40,7 @@ locals {
   app_host                  = "staging.submit-social-housing-data.levellingup.gov.uk"
   app_task_desired_count    = 2
   application_port          = 8080
+  create_replica_standby_db = false
   database_port             = 5432
   load_balancer_domain_name = "staging.lb.submit-social-housing-data.levellingup.gov.uk"
   provider_role_arn         = "arn:aws:iam::107155005276:role/developer"
@@ -109,15 +110,16 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  prefix                  = local.prefix
-  allocated_storage       = 25
-  backup_retention_period = 7
-  database_port           = local.database_port
-  db_subnet_group_name    = module.networking.db_private_subnet_group_name
-  ecs_security_group_id   = module.application.ecs_security_group_id
-  instance_class          = "db.t3.micro"
-  sns_topic_arn           = module.monitoring.sns_topic_arn
-  vpc_id                  = module.networking.vpc_id
+  prefix                    = local.prefix
+  allocated_storage         = 25
+  backup_retention_period   = 7
+  create_replica_standby_db = local.create_replica_standby_db
+  database_port             = local.database_port
+  db_subnet_group_name      = module.networking.db_private_subnet_group_name
+  ecs_security_group_id     = module.application.ecs_security_group_id
+  instance_class            = "db.t3.micro"
+  sns_topic_arn             = module.monitoring.sns_topic_arn
+  vpc_id                    = module.networking.vpc_id
 }
 
 module "front_door" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -40,7 +40,6 @@ locals {
   app_host                  = "staging.submit-social-housing-data.levellingup.gov.uk"
   app_task_desired_count    = 2
   application_port          = 8080
-  create_replica_standby_db = true
   database_port             = 5432
   load_balancer_domain_name = "staging.lb.submit-social-housing-data.levellingup.gov.uk"
   provider_role_arn         = "arn:aws:iam::107155005276:role/developer"
@@ -113,10 +112,10 @@ module "database" {
   prefix                    = local.prefix
   allocated_storage         = 25
   backup_retention_period   = 7
-  create_replica_standby_db = local.create_replica_standby_db
   database_port             = local.database_port
   db_subnet_group_name      = module.networking.db_private_subnet_group_name
   ecs_security_group_id     = module.application.ecs_security_group_id
+  highly_available          = true
   instance_class            = "db.t3.micro"
   sns_topic_arn             = module.monitoring.sns_topic_arn
   vpc_id                    = module.networking.vpc_id

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -40,7 +40,7 @@ locals {
   app_host                  = "staging.submit-social-housing-data.levellingup.gov.uk"
   app_task_desired_count    = 2
   application_port          = 8080
-  create_replica_standby_db = false
+  create_replica_standby_db = true
   database_port             = 5432
   load_balancer_domain_name = "staging.lb.submit-social-housing-data.levellingup.gov.uk"
   provider_role_arn         = "arn:aws:iam::107155005276:role/developer"


### PR DESCRIPTION
- Implement a single DB read replica (i.e. Multi-AZ DB instance rather than cluster). I agree this is probably what Gov PaaS uses, and one replica is probably sufficient for CORE's requirements
- Implement a flag dictating if the replica will be made in the infra
- Set the flag to true for Prod only (staging is only true for now in case we need to test anything else during review, but will be removed once we're satisfied)
- I tested a DB failover using the instructions [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html), essentially rebooting our primary DB with a failover. I could see the read replica take over, and a new replica take its place. The app seemed to handle failover fine. I was logged into CORE viewing lettings logs, triggered a failover and tried to load some pages during it. The pages took some time to load (~10's of seconds) but did succeed. The ECS logs also didn't seem to note any app errors talking to the DB. The AWS docs [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZSingleStandby.html) suggest your app cleans and re-establishes any DB connections, but I suspect ActiveRecord may be handling this already.