### PR TITLE
CLDC-2786: Sidekiq alarms

### DIFF
--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_service_action_problem" {
 resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-sidekiq-running-tasks"
-  comparison_operator       = "LessOrEqualToThanThreshold"
+  comparison_operator       = "LessThanOrEqualToThreshold"
   datapoints_to_alarm       = 1
   evaluation_periods        = 1
   metric_name               = "RunningTaskCount"

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -160,11 +160,11 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
   comparison_operator       = "LessThanThreshold"
   datapoints_to_alarm       = 1
   evaluation_periods        = 1
-  metric_name               = "RunningTaskCount"
-  namespace                 = "ECS/ContainerInsights"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/ECS"
   ok_actions                = [var.sns_topic_arn]
   period                    = 60
-  statistic                 = "Minimum"
+  statistic                 = "SampleCount"
   threshold                 = var.sidekiq_task_desired_count
   insufficient_data_actions = []
 

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -153,3 +153,23 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_service_action_problem" {
     RuleName = aws_cloudwatch_event_rule.sidekiq_service_action_problem.name
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
+  alarm_actions             = [var.sns_topic_arn]
+  alarm_name                = "${var.prefix}-sidekiq-running-tasks"
+  comparison_operator       = "LessOrEqualToThanThreshold"
+  datapoints_to_alarm       = 1
+  evaluation_periods        = 1
+  metric_name               = "RunningTaskCount"
+  namespace                 = "ECS/ContainerInsights"
+  ok_actions                = [var.sns_topic_arn]
+  period                    = 60
+  statistic                 = "Minimum"
+  threshold                 = var.sidekiq_task_desired_count
+  insufficient_data_actions = []
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.this.name
+    ServiceName = aws_ecs_service.sidekiq.name
+  }
+}

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_service_action_problem" {
 resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
   alarm_actions             = [var.sns_topic_arn]
   alarm_name                = "${var.prefix}-sidekiq-running-tasks"
-  comparison_operator       = "LessThanOrEqualToThreshold"
+  comparison_operator       = "LessThanThreshold"
   datapoints_to_alarm       = 1
   evaluation_periods        = 1
   metric_name               = "RunningTaskCount"

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -2,6 +2,11 @@
 resource "aws_ecs_cluster" "this" {
   #checkov:skip=CKV_AWS_65:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
   name = var.prefix
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 locals {

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -2,11 +2,6 @@
 resource "aws_ecs_cluster" "this" {
   #checkov:skip=CKV_AWS_65:TODO CLDC-2542 enable container insights if necessary for logging/monitoring
   name = "${var.prefix}-app"
-
-  setting {
-    name  = "containerInsights"
-    value = "enabled"
-  }
 }
 
 locals {

--- a/terraform/modules/application/events.tf
+++ b/terraform/modules/application/events.tf
@@ -42,3 +42,48 @@ resource "aws_cloudwatch_event_rule" "app_service_action_problem" {
     }
   )
 }
+
+resource "aws_cloudwatch_event_rule" "sidekiq_task_exited" {
+  name = "${var.prefix}-sidekiq-task-exited"
+
+  event_pattern = jsonencode(
+    {
+      "source" : [
+        "aws.ecs"
+      ],
+      "detail-type" : [
+        "ECS Task State Change"
+      ],
+      "detail" : {
+        "group" : [
+          "service:${aws_ecs_service.sidekiq.name}"
+        ],
+        "stoppedReason" : [
+          "Essential container in task exited"
+        ]
+      }
+    }
+  )
+}
+
+resource "aws_cloudwatch_event_rule" "sidekiq_service_action_problem" {
+  name = "${var.prefix}-sidekiq-service-action-problem"
+
+  # This event pattern was used based on the answer here: https://serverfault.com/questions/1012603/create-a-cloudwatch-alarm-when-an-ecs-service-unable-to-consistently-start-tasks.
+  event_pattern = jsonencode(
+    {
+      "source" : [
+        "aws.ecs"
+      ],
+      "detail-type" : [
+        "ECS Service Action"
+      ],
+      "resources" : [
+        aws_ecs_service.sidekiq.id
+      ],
+      "detail" : {
+        "eventType" : ["WARN", "ERROR"]
+      }
+    }
+  )
+}


### PR DESCRIPTION
I couldn't create healthy/unhealthy hosts alarms for sidekiq because there's no target group. I think it's fine not to have these given we're not expecting sidekiq tasks to fail anywhere near as much as the app tasks (correct me if I'm wrong!)