### PR TITLE
CLDC-2687: Update apply_immediately for rds & redis

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -122,11 +122,11 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  allocated_storage       = 5
+  allocated_storage         = 5
   apply_changes_immediately = true
-  backup_retention_period = 7
-  highly_available        = false
-  instance_class          = "db.t3.micro"
+  backup_retention_period   = 7
+  highly_available          = false
+  instance_class            = "db.t3.micro"
 
   prefix = local.prefix
 
@@ -179,8 +179,8 @@ module "redis" {
   source = "../modules/elasticache"
 
   apply_changes_immediately = true
-  highly_available = false
-  node_type        = "cache.t4g.micro"
+  highly_available          = false
+  node_type                 = "cache.t4g.micro"
 
   prefix                  = local.prefix
   ecs_security_group_id   = module.application_security_group.ecs_security_group_id

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -123,6 +123,7 @@ module "database" {
   source = "../modules/rds"
 
   allocated_storage       = 5
+  apply_changes_immediately = true
   backup_retention_period = 7
   highly_available        = false
   instance_class          = "db.t3.micro"
@@ -177,6 +178,7 @@ module "monitoring" {
 module "redis" {
   source = "../modules/elasticache"
 
+  apply_changes_immediately = true
   highly_available = false
   node_type        = "cache.t4g.micro"
 

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_replication_group" "this" {
 
   count = var.highly_available ? 1 : 0
 
-  apply_immediately           = true
+  apply_immediately           = var.apply_changes_immediately
   at_rest_encryption_enabled  = true
   auto_minor_version_upgrade  = true
   automatic_failover_enabled  = true
@@ -32,7 +32,7 @@ resource "aws_elasticache_cluster" "this" {
   count = var.highly_available ? 0 : 1
 
   cluster_id                 = var.prefix
-  apply_immediately          = true
+  apply_immediately          = var.apply_changes_immediately
   auto_minor_version_upgrade = true
   engine                     = "redis"
   engine_version             = "6.2"

--- a/terraform/modules/elasticache/variables.tf
+++ b/terraform/modules/elasticache/variables.tf
@@ -1,3 +1,8 @@
+variable "apply_changes_immediately" {
+  type        = bool
+  description = "Whether to apply changes to redis immediately or to wait for the next maintenance window."
+}
+
 variable "ecs_security_group_id" {
   type        = string
   description = "The id of the ecs security group for ecs ingress"

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -8,7 +8,7 @@ resource "aws_db_instance" "this" {
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
   #checkov:skip=CKV2_AWS_30:query logging TODO CLDC-2660
   identifier                 = var.prefix
-  apply_immediately          = true
+  apply_immediately          = var.apply_changes_immediately
   auto_minor_version_upgrade = true
   allocated_storage          = var.allocated_storage #units are GiB
   backup_retention_period    = var.backup_retention_period

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -3,6 +3,11 @@ variable "allocated_storage" {
   description = "The allocated DB storage in gibibytes."
 }
 
+variable "apply_changes_immediately" {
+  type        = bool
+  description = "Whether to apply changes to the db immediately or to wait for the next maintenance window."
+}
+
 variable "database_port" {
   type        = number
   description = "The network port the database runs on"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -126,11 +126,11 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  allocated_storage       = 100
+  allocated_storage         = 100
   apply_changes_immediately = false
-  backup_retention_period = 7
-  highly_available        = true
-  instance_class          = "db.t3.small"
+  backup_retention_period   = 7
+  highly_available          = true
+  instance_class            = "db.t3.small"
 
   prefix = local.prefix
 
@@ -183,8 +183,8 @@ module "redis" {
   source = "../modules/elasticache"
 
   apply_changes_immediately = false
-  highly_available = true
-  node_type        = "cache.t4g.micro"
+  highly_available          = true
+  node_type                 = "cache.t4g.micro"
 
   prefix                  = local.prefix
   ecs_security_group_id   = module.application_security_group.ecs_security_group_id

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -127,6 +127,7 @@ module "database" {
   source = "../modules/rds"
 
   allocated_storage       = 100
+  apply_changes_immediately = false
   backup_retention_period = 7
   highly_available        = true
   instance_class          = "db.t3.small"
@@ -181,6 +182,7 @@ module "monitoring" {
 module "redis" {
   source = "../modules/elasticache"
 
+  apply_changes_immediately = false
   highly_available = true
   node_type        = "cache.t4g.micro"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -126,11 +126,11 @@ module "certificates" {
 module "database" {
   source = "../modules/rds"
 
-  allocated_storage       = 25
+  allocated_storage         = 25
   apply_changes_immediately = true
-  backup_retention_period = 7
-  highly_available        = false
-  instance_class          = "db.t3.micro"
+  backup_retention_period   = 7
+  highly_available          = false
+  instance_class            = "db.t3.micro"
 
   prefix = local.prefix
 
@@ -183,8 +183,8 @@ module "redis" {
   source = "../modules/elasticache"
 
   apply_changes_immediately = true
-  highly_available = true
-  node_type        = "cache.t4g.micro"
+  highly_available          = true
+  node_type                 = "cache.t4g.micro"
 
   prefix                  = local.prefix
   ecs_security_group_id   = module.application_security_group.ecs_security_group_id

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -127,6 +127,7 @@ module "database" {
   source = "../modules/rds"
 
   allocated_storage       = 25
+  apply_changes_immediately = true
   backup_retention_period = 7
   highly_available        = false
   instance_class          = "db.t3.micro"
@@ -181,6 +182,7 @@ module "monitoring" {
 module "redis" {
   source = "../modules/elasticache"
 
+  apply_changes_immediately = true
   highly_available = true
   node_type        = "cache.t4g.micro"
 


### PR DESCRIPTION
Whether or not to apply changes immediately to rds and redis has been pulled out into a variable for each of those modules (as we want to apply changes immediately for some environments but not others).