### PR TITLE
CLDC-2779: Update logging in migration work

### DIFF
--- a/terraform/modules/application/logging.tf
+++ b/terraform/modules/application/logging.tf
@@ -3,7 +3,7 @@
 resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:TODO CLDC-2542 create and encrypt with a KMS key if retaining this log group
   #checkov:skip=CKV_AWS_338:TODO CLDC-2542 retaining logs for at least 1year greater than necessary for debugging ecs
-  name              = "${var.prefix}-app-ecs"
+  name              = "${var.prefix}-app"
   retention_in_days = 14
 
   tags = {

--- a/terraform/modules/rds_migration/ecs.tf
+++ b/terraform/modules/rds_migration/ecs.tf
@@ -26,6 +26,8 @@ resource "aws_ecs_task_definition" "db_migration" {
           awslogs-group         = aws_cloudwatch_log_group.this.id
           awslogs-region        = "eu-west-2"
           awslogs-stream-prefix = var.prefix
+          mode                  = "non-blocking"
+          max-buffer-size       = "4m" # See this analysis of how to choose a buffer size in non-blocking mode: https://github.com/moby/moby/issues/45999.
         }
       }
 
@@ -77,6 +79,8 @@ resource "aws_ecs_task_definition" "exec_placeholder" {
           awslogs-group         = aws_cloudwatch_log_group.this.id
           awslogs-region        = "eu-west-2"
           awslogs-stream-prefix = var.prefix
+          mode                  = "non-blocking"
+          max-buffer-size       = "4m" # See this analysis of how to choose a buffer size in non-blocking mode: https://github.com/moby/moby/issues/45999.
         }
       }
 

--- a/terraform/modules/rds_migration/logging.tf
+++ b/terraform/modules/rds_migration/logging.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:TODO CLDC-2779 create and encrypt with a KMS key if retaining this log group
   #checkov:skip=CKV_AWS_338:TODO CLDC-2779 retaining logs for at least 1year greater than necessary for debugging ecs
   name              = "${var.prefix}-db-migration"
-  retention_in_days = 14
+  retention_in_days = 60
 
   tags = {
     Application = var.prefix

--- a/terraform/modules/rds_migration/logging.tf
+++ b/terraform/modules/rds_migration/logging.tf
@@ -3,7 +3,7 @@
 resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:TODO CLDC-2779 create and encrypt with a KMS key if retaining this log group
   #checkov:skip=CKV_AWS_338:TODO CLDC-2779 retaining logs for at least 1year greater than necessary for debugging ecs
-  name              = "${var.prefix}-db-migration-ecs"
+  name              = "${var.prefix}-db-migration"
   retention_in_days = 14
 
   tags = {


### PR DESCRIPTION
As part of [CLDC-2779](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/60/files) I made some changes to logging which I wanted to make sure were replicated here (and I thought this was a nicer solution than waiting for the [migration PR](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure/pull/49/files) to be merged to main).

The migration work doesn't have a 'role task' in the rds_migration module (unlike the application module). If that gets introduced, we should ensure it has the same (reduced) permissions as in the application module.