### PR TITLE
CLDC-2909: Restrict http access to bulk upload and cds export buckets

### DIFF
--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_policy" "force_ssl" {
   bucket = aws_s3_bucket.this.id
 
   policy = jsonencode({
-    "Version" : "2012-10-17",
+    Version = "2012-10-17",
     Statement = [
       {
         Sid       = "AllowSSLRequestsOnly",

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -25,14 +25,14 @@ resource "aws_s3_bucket_policy" "force_ssl" {
   bucket = aws_s3_bucket.this.id
 
   policy = jsonencode({
-    "Version": "2012-10-17",
+    "Version" : "2012-10-17",
     Statement = [
       {
         Sid       = "AllowSSLRequestsOnly",
         Action    = "s3:*",
         Effect    = "Deny",
         Principal = "*",
-        Resource  = [
+        Resource = [
           aws_s3_bucket.this.arn,
           "${aws_s3_bucket.this.arn}/*"
         ],

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -20,6 +20,32 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = true
 }
 
+
+resource "aws_s3_bucket_policy" "force_ssl" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowSSLRequestsOnly",
+        Action    = "s3:*",
+        Effect    = "Deny",
+        Principal = "*",
+        Resource  = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        },
+      },
+    ],
+  })
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -20,6 +20,31 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_policy" "force_ssl" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowSSLRequestsOnly",
+        Action    = "s3:*",
+        Effect    = "Deny",
+        Principal = "*",
+        Resource  = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        },
+      },
+    ],
+  })
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -24,7 +24,7 @@ resource "aws_s3_bucket_policy" "force_ssl" {
   bucket = aws_s3_bucket.this.id
 
   policy = jsonencode({
-    "Version" : "2012-10-17",
+    Version = "2012-10-17",
     Statement = [
       {
         Sid       = "AllowSSLRequestsOnly",

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -24,14 +24,14 @@ resource "aws_s3_bucket_policy" "force_ssl" {
   bucket = aws_s3_bucket.this.id
 
   policy = jsonencode({
-    "Version": "2012-10-17",
+    "Version" : "2012-10-17",
     Statement = [
       {
         Sid       = "AllowSSLRequestsOnly",
         Action    = "s3:*",
         Effect    = "Deny",
         Principal = "*",
-        Resource  = [
+        Resource = [
           aws_s3_bucket.this.arn,
           "${aws_s3_bucket.this.arn}/*"
         ],


### PR DESCRIPTION
- Restrict the ability to make http connections with the our `bulk upload` and `cds export` buckets

I've checked the state and state replica buckets in the meta account, they both already have this enabled (through the external modules)