### PR TITLE
CLDC-2908: Implement access logging for bulk upload and cds export buckets

### DIFF
--- a/terraform/modules/bulk_upload/access_log_bucket.tf
+++ b/terraform/modules/bulk_upload/access_log_bucket.tf
@@ -1,10 +1,10 @@
-#tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
+#tfsec:ignore:aws-s3-enable-bucket-encryption: access log buckets not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
 #tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
-#tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
+#tfsec:ignore:aws-s3-encryption-customer-key: access log buckets are not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
 resource "aws_s3_bucket" "bulk_upload_access_logs" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
   #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
-  #checkov:skip=CKV_AWS_145: default encryption is fine
+  #checkov:skip=CKV_AWS_145: access log buckets are not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
   #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
   bucket = "${var.prefix}-bulk-upload-logs"
 }

--- a/terraform/modules/bulk_upload/access_log_bucket.tf
+++ b/terraform/modules/bulk_upload/access_log_bucket.tf
@@ -29,23 +29,25 @@ resource "aws_s3_bucket_policy" "allow_access_logs" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid       = "S3ServerAccessLogsPolicy",
-        Action    = "s3:PutObject",
-        Effect    = "Allow",
-        Principal = "logging.s3.amazonaws.com",
+        Sid    = "S3ServerAccessLogsPolicy",
+        Action = "s3:PutObject",
+        Effect = "Allow",
+        Principal = {
+          "Service" = "logging.s3.amazonaws.com"
+        },
         Resource = [
           "${aws_s3_bucket.bulk_upload_access_logs.arn}/*"
         ],
         Condition = {
           ArnLike = {
             "aws:SourceArn" = aws_s3_bucket.bulk_upload.arn
-          }
+          },
           StringEquals = {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
-        },
-      },
-    ],
+        }
+      }
+    ]
   })
 }
 

--- a/terraform/modules/bulk_upload/access_log_bucket.tf
+++ b/terraform/modules/bulk_upload/access_log_bucket.tf
@@ -1,0 +1,70 @@
+#tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
+#tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
+#tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
+#tfsec:ignore:aws-s3-enable-versioning: Not important, each log will be a new file with a different name
+resource "aws_s3_bucket" "bulk_upload_access_logs" {
+  #checkov:skip=CKV2_AWS_62: no need for event notifications
+  #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
+  #checkov:skip=CKV_AWS_145: default encryption is fine
+  #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
+  #checkov:skip=CKV_AWS_21: versioning not important, each log will be a new file with a different name
+  bucket = "${var.prefix}-bulk-upload-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "bulk_upload_access_logs" {
+  bucket = aws_s3_bucket.bulk_upload_access_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "allow_access_logs" {
+  bucket = aws_s3_bucket.bulk_upload_access_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "S3ServerAccessLogsPolicy",
+        Action    = "s3:PutObject",
+        Effect    = "Allow",
+        Principal = "logging.s3.amazonaws.com",
+        Resource = [
+          "${aws_s3_bucket.bulk_upload_access_logs.arn}/*"
+        ],
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = aws_s3_bucket.bulk_upload.arn
+          }
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        },
+      },
+    ],
+  })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bulk_upload_access_logs" {
+  bucket = aws_s3_bucket.bulk_upload_access_logs.id
+
+  rule {
+    id = "expire-old-logs"
+
+    filter {}
+
+    expiration {
+      days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
+    status = "Enabled"
+  }
+}

--- a/terraform/modules/bulk_upload/access_log_bucket.tf
+++ b/terraform/modules/bulk_upload/access_log_bucket.tf
@@ -1,13 +1,11 @@
 #tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
 #tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
 #tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
-#tfsec:ignore:aws-s3-enable-versioning: Not important, each log will be a new file with a different name
 resource "aws_s3_bucket" "bulk_upload_access_logs" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
   #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
-  #checkov:skip=CKV_AWS_21: versioning not important, each log will be a new file with a different name
   bucket = "${var.prefix}-bulk-upload-logs"
 }
 

--- a/terraform/modules/bulk_upload/access_log_bucket.tf
+++ b/terraform/modules/bulk_upload/access_log_bucket.tf
@@ -18,7 +18,9 @@ resource "aws_s3_bucket_public_access_block" "bulk_upload_access_logs" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_policy" "force_ssl_access_logs" {
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "force_ssl_and_allow_access_logs" {
   bucket = aws_s3_bucket.bulk_upload_access_logs.id
 
   policy = jsonencode({
@@ -38,21 +40,9 @@ resource "aws_s3_bucket_policy" "force_ssl_access_logs" {
             "aws:SecureTransport" = "false"
           }
         }
-      }
-    ]
-  })
-}
-
-data "aws_caller_identity" "current" {}
-
-resource "aws_s3_bucket_policy" "allow_access_logs" {
-  bucket = aws_s3_bucket.bulk_upload_access_logs.id
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
+      },
       {
-        Sid    = "S3ServerAccessLogsPolicy",
+        Sid    = "AllowS3AccessLogs",
         Action = "s3:PutObject",
         Effect = "Allow",
         Principal = {

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -1,18 +1,22 @@
 #tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
 #tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
-#tfsec:ignore:aws-s3-enable-bucket-logging: TODO CLDC-2728
 #tfsec:ignore:aws-s3-enable-versioning: Not important, each upload creates a new file with a different name (a random UUID)
-resource "aws_s3_bucket" "this" {
+resource "aws_s3_bucket" "bulk_upload" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
-  #checkov:skip=CKV_AWS_18: access logging - TODO CLDC-2728
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication is overkill when this is only for data transfer
   #checkov:skip=CKV_AWS_21: versioning not important, each upload creates a new file with a different name (a random UUID)
   bucket = "${var.prefix}-bulk-upload"
 }
 
-resource "aws_s3_bucket_public_access_block" "this" {
-  bucket = aws_s3_bucket.this.id
+resource "aws_s3_bucket_logging" "access_logging" {
+  bucket        = aws_s3_bucket.bulk_upload.id
+  target_bucket = aws_s3_bucket.bulk_upload_access_logs.id
+  target_prefix = ""
+}
+
+resource "aws_s3_bucket_public_access_block" "bulk_upload" {
+  bucket = aws_s3_bucket.bulk_upload.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -20,8 +24,8 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "this" {
-  bucket = aws_s3_bucket.this.id
+resource "aws_s3_bucket_lifecycle_configuration" "bulk_upload" {
+  bucket = aws_s3_bucket.bulk_upload.id
 
   rule {
     id = "expire-old-data"
@@ -44,13 +48,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 data "aws_iam_policy_document" "read_write" {
   statement {
     actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.this.arn]
+    resources = [aws_s3_bucket.bulk_upload.arn]
     effect    = "Allow"
   }
 
   statement {
     actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-    resources = ["${aws_s3_bucket.this.arn}/*"]
+    resources = ["${aws_s3_bucket.bulk_upload.arn}/*"]
     effect    = "Allow"
   }
 }

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -43,9 +43,9 @@ resource "aws_s3_bucket_policy" "force_ssl" {
           Bool = {
             "aws:SecureTransport" = "false"
           }
-        },
-      },
-    ],
+        }
+      }
+    ]
   })
 }
 

--- a/terraform/modules/bulk_upload/bucket.tf
+++ b/terraform/modules/bulk_upload/bucket.tf
@@ -69,31 +69,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "bulk_upload" {
   }
 }
 
-resource "aws_s3_bucket_policy" "force_ssl" {
-  bucket = aws_s3_bucket.bulk_upload.id
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid       = "AllowSSLRequestsOnly",
-        Action    = "s3:*",
-        Effect    = "Deny",
-        Principal = "*",
-        Resource = [
-          aws_s3_bucket.bulk_upload.arn,
-          "${aws_s3_bucket.bulk_upload.arn}/*"
-        ],
-        Condition = {
-          Bool = {
-            "aws:SecureTransport" = "false"
-          }
-        },
-      },
-    ],
-  })
-}
-
 #tfsec:ignore:aws-iam-no-policy-wildcards: require access to all objects in bucket
 data "aws_iam_policy_document" "read_write" {
   statement {

--- a/terraform/modules/bulk_upload/outputs.tf
+++ b/terraform/modules/bulk_upload/outputs.tf
@@ -1,5 +1,5 @@
 output "details" {
-  value       = { aws_region : aws_s3_bucket.this.region, bucket_name : aws_s3_bucket.this.id }
+  value       = { aws_region : aws_s3_bucket.bulk_upload.region, bucket_name : aws_s3_bucket.bulk_upload.id }
   description = "Details block for this bucket for the application to use to connect"
 }
 

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -1,13 +1,11 @@
 #tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
 #tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
 #tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
-#tfsec:ignore:aws-s3-enable-versioning: Not important, each log will be a new file with a different name
 resource "aws_s3_bucket" "export_access_logs" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
   #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
-  #checkov:skip=CKV_AWS_21: versioning not important, each log will be a new file with a different name
   bucket = "${var.prefix}-export${var.bucket_suffix}-logs"
 }
 

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -1,0 +1,70 @@
+#tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
+#tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
+#tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
+#tfsec:ignore:aws-s3-enable-versioning: Not important, each log will be a new file with a different name
+resource "aws_s3_bucket" "export_access_logs" {
+  #checkov:skip=CKV2_AWS_62: no need for event notifications
+  #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
+  #checkov:skip=CKV_AWS_145: default encryption is fine
+  #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
+  #checkov:skip=CKV_AWS_21: versioning not important, each log will be a new file with a different name
+  bucket = "${var.prefix}-export${var.bucket_suffix}-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "export_access_logs" {
+  bucket = aws_s3_bucket.export_access_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "allow_access_logs" {
+  bucket = aws_s3_bucket.export_access_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "S3ServerAccessLogsPolicy",
+        Action    = "s3:PutObject",
+        Effect    = "Allow",
+        Principal = "logging.s3.amazonaws.com",
+        Resource = [
+          "${aws_s3_bucket.export_access_logs.arn}/*"
+        ],
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = aws_s3_bucket.export.arn
+          }
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        },
+      },
+    ],
+  })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "export_access_logs" {
+  bucket = aws_s3_bucket.export_access_logs.id
+
+  rule {
+    id = "expire-old-logs"
+
+    filter {}
+
+    expiration {
+      days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
+    status = "Enabled"
+  }
+}

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -20,6 +20,31 @@ resource "aws_s3_bucket_public_access_block" "export_access_logs" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_policy" "force_ssl_access_logs" {
+  bucket = aws_s3_bucket.export_access_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowSSLRequestsOnly",
+        Action    = "s3:*",
+        Effect    = "Deny",
+        Principal = "*",
+        Resource = [
+          aws_s3_bucket.export_access_logs.arn,
+          "${aws_s3_bucket.export_access_logs.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_policy" "allow_access_logs" {
@@ -51,22 +76,38 @@ resource "aws_s3_bucket_policy" "allow_access_logs" {
   })
 }
 
+resource "aws_s3_bucket_versioning" "export_access_logs" {
+  bucket = aws_s3_bucket.export_access_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "export_access_logs" {
   bucket = aws_s3_bucket.export_access_logs.id
 
   rule {
-    id = "expire-old-logs"
-
-    filter {}
-
-    expiration {
-      days = 90
-    }
+    id     = "expire-old-logs"
+    status = "Enabled"
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
     }
 
-    status = "Enabled"
+    expiration {
+      days = 90
+    }
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
   }
 }

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -18,7 +18,9 @@ resource "aws_s3_bucket_public_access_block" "export_access_logs" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_policy" "force_ssl_access_logs" {
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "force_ssl_and_allow_access_logs" {
   bucket = aws_s3_bucket.export_access_logs.id
 
   policy = jsonencode({
@@ -38,21 +40,9 @@ resource "aws_s3_bucket_policy" "force_ssl_access_logs" {
             "aws:SecureTransport" = "false"
           }
         }
-      }
-    ]
-  })
-}
-
-data "aws_caller_identity" "current" {}
-
-resource "aws_s3_bucket_policy" "allow_access_logs" {
-  bucket = aws_s3_bucket.export_access_logs.id
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
+      },
       {
-        Sid    = "S3ServerAccessLogsPolicy",
+        Sid    = "AllowS3AccessLogs",
         Action = "s3:PutObject",
         Effect = "Allow",
         Principal = {

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -29,23 +29,25 @@ resource "aws_s3_bucket_policy" "allow_access_logs" {
     Version = "2012-10-17",
     Statement = [
       {
-        Sid       = "S3ServerAccessLogsPolicy",
-        Action    = "s3:PutObject",
-        Effect    = "Allow",
-        Principal = "logging.s3.amazonaws.com",
+        Sid    = "S3ServerAccessLogsPolicy",
+        Action = "s3:PutObject",
+        Effect = "Allow",
+        Principal = {
+          "Service" = "logging.s3.amazonaws.com"
+        },
         Resource = [
           "${aws_s3_bucket.export_access_logs.arn}/*"
         ],
         Condition = {
           ArnLike = {
             "aws:SourceArn" = aws_s3_bucket.export.arn
-          }
+          },
           StringEquals = {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
-        },
-      },
-    ],
+        }
+      }
+    ]
   })
 }
 

--- a/terraform/modules/cds_export/access_log_bucket.tf
+++ b/terraform/modules/cds_export/access_log_bucket.tf
@@ -1,10 +1,10 @@
-#tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
+#tfsec:ignore:aws-s3-enable-bucket-encryption: access log buckets not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
 #tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
-#tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
+#tfsec:ignore:aws-s3-encryption-customer-key: access log buckets are not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
 resource "aws_s3_bucket" "export_access_logs" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
   #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
-  #checkov:skip=CKV_AWS_145: default encryption is fine
+  #checkov:skip=CKV_AWS_145: access log buckets are not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
   #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
   bucket = "${var.prefix}-export${var.bucket_suffix}-logs"
 }

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -1,18 +1,22 @@
 #tfsec:ignore:aws-s3-enable-bucket-encryption: default bucket encryption is sufficient
 #tfsec:ignore:aws-s3-encryption-customer-key: default encryption is sufficient
-#tfsec:ignore:aws-s3-enable-bucket-logging: TODO CLDC-2720
 #tfsec:ignore:aws-s3-enable-versioning: Not important, source of data is application db
-resource "aws_s3_bucket" "this" {
+resource "aws_s3_bucket" "export" {
   #checkov:skip=CKV2_AWS_62: no need for event notifications
-  #checkov:skip=CKV_AWS_18: access logging - TODO CLDC-2720
   #checkov:skip=CKV_AWS_145: default encryption is fine
   #checkov:skip=CKV_AWS_144: cross region replication is overkill when this is only for data transfer
   #checkov:skip=CKV_AWS_21: versioning not important, data source is elsewhere
   bucket = "${var.prefix}-export${var.bucket_suffix}"
 }
 
-resource "aws_s3_bucket_public_access_block" "this" {
-  bucket = aws_s3_bucket.this.id
+resource "aws_s3_bucket_logging" "access_logging" {
+  bucket        = aws_s3_bucket.export.id
+  target_bucket = aws_s3_bucket.export_access_logs.id
+  target_prefix = ""
+}
+
+resource "aws_s3_bucket_public_access_block" "export" {
+  bucket = aws_s3_bucket.export.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -20,8 +24,8 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "this" {
-  bucket = aws_s3_bucket.this.id
+resource "aws_s3_bucket_lifecycle_configuration" "export" {
+  bucket = aws_s3_bucket.export.id
 
   rule {
     id = "expire-old-data"

--- a/terraform/modules/cds_export/bucket.tf
+++ b/terraform/modules/cds_export/bucket.tf
@@ -44,9 +44,9 @@ resource "aws_s3_bucket_policy" "force_ssl" {
           Bool = {
             "aws:SecureTransport" = "false"
           }
-        },
-      },
-    ],
+        }
+      }
+    ]
   })
 }
 

--- a/terraform/modules/cds_export/outputs.tf
+++ b/terraform/modules/cds_export/outputs.tf
@@ -1,5 +1,5 @@
 output "details" {
-  value       = { aws_region : aws_s3_bucket.this.region, bucket_name : aws_s3_bucket.this.id }
+  value       = { aws_region : aws_s3_bucket.export.region, bucket_name : aws_s3_bucket.export.id }
   description = "Details block for this bucket for the application to use to connect"
 }
 

--- a/terraform/modules/cds_export/role_cds.tf
+++ b/terraform/modules/cds_export/role_cds.tf
@@ -32,13 +32,13 @@ data "aws_iam_policy_document" "export_bucket_read_only_access" {
 
   statement {
     actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.this.arn]
+    resources = [aws_s3_bucket.export.arn]
     effect    = "Allow"
   }
 
   statement {
     actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.this.arn}/*"]
+    resources = ["${aws_s3_bucket.export.arn}/*"]
     effect    = "Allow"
   }
 }

--- a/terraform/modules/cds_export/role_task_policy.tf
+++ b/terraform/modules/cds_export/role_task_policy.tf
@@ -2,13 +2,13 @@
 data "aws_iam_policy_document" "read_write" {
   statement {
     actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.this.arn]
+    resources = [aws_s3_bucket.export.arn]
     effect    = "Allow"
   }
 
   statement {
     actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-    resources = ["${aws_s3_bucket.this.arn}/*"]
+    resources = ["${aws_s3_bucket.export.arn}/*"]
     effect    = "Allow"
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -272,20 +272,19 @@ module "bulk_upload" {
   prefix = local.prefix
 }
 
-
 moved {
   from = module.cds_export.aws_s3_bucket.this
   to   = module.cds_export.aws_s3_bucket.export
 }
 
 moved {
-  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
-  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
+  from = module.cds_export.aws_s3_bucket_public_access_block.this
+  to   = module.cds_export.aws_s3_bucket_public_access_block.export
 }
 
 moved {
-  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
-  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
+  from = module.cds_export.aws_s3_bucket_lifecycle_configuration.this
+  to   = module.cds_export.aws_s3_bucket_lifecycle_configuration.export
 }
 
 module "cds_export" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -251,10 +251,41 @@ module "application_security_group" {
   vpc_id                          = module.networking.vpc_id
 }
 
+moved {
+  from = module.bulk_upload.aws_s3_bucket.this
+  to   = module.bulk_upload.aws_s3_bucket.bulk_upload
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
+  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
+  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
+}
+
 module "bulk_upload" {
   source = "../modules/bulk_upload"
 
   prefix = local.prefix
+}
+
+
+moved {
+  from = module.cds_export.aws_s3_bucket.this
+  to   = module.cds_export.aws_s3_bucket.export
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
+  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
+  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
 }
 
 module "cds_export" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -265,10 +265,40 @@ module "application_security_group" {
   vpc_id                          = module.networking.vpc_id
 }
 
+moved {
+  from = module.bulk_upload.aws_s3_bucket.this
+  to   = module.bulk_upload.aws_s3_bucket.bulk_upload
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
+  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
+}
+
+moved {
+  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
+  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
+}
 module "bulk_upload" {
   source = "../modules/bulk_upload"
 
   prefix = local.prefix
+}
+
+
+moved {
+  from = module.cds_export.aws_s3_bucket.this
+  to   = module.cds_export.aws_s3_bucket.export
+}
+
+moved {
+  from = module.cds_export.aws_s3_bucket_public_access_block.this
+  to   = module.cds_export.aws_s3_bucket_public_access_block.export
+}
+
+moved {
+  from = module.cds_export.aws_s3_bucket_lifecycle_configuration.this
+  to   = module.cds_export.aws_s3_bucket_lifecycle_configuration.export
 }
 
 module "cds_export" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -135,40 +135,10 @@ module "application_security_group" {
   vpc_id                          = module.networking.vpc_id
 }
 
-moved {
-  from = module.bulk_upload.aws_s3_bucket.this
-  to   = module.bulk_upload.aws_s3_bucket.bulk_upload
-}
-
-moved {
-  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
-  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
-}
-
-moved {
-  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
-  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
-}
-
 module "bulk_upload" {
   source = "../modules/bulk_upload"
 
   prefix = local.prefix
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket.this
-  to   = module.cds_export.aws_s3_bucket.export
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket_public_access_block.this
-  to   = module.cds_export.aws_s3_bucket_public_access_block.export
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket_lifecycle_configuration.this
-  to   = module.cds_export.aws_s3_bucket_lifecycle_configuration.export
 }
 
 module "cds_export" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -279,12 +279,12 @@ moved {
   from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
   to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
 }
+
 module "bulk_upload" {
   source = "../modules/bulk_upload"
 
   prefix = local.prefix
 }
-
 
 moved {
   from = module.cds_export.aws_s3_bucket.this


### PR DESCRIPTION
- Enable access logging on the bulk upload and cds export buckets, with the logs going to the separate dedicated log buckets
- Check the access logs appear in the dedicated buckets ✅