### PR TITLE
Allow github actions to list ecr images

### DIFF
--- a/terraform/modules/github_actions_access/app_repo_role.tf
+++ b/terraform/modules/github_actions_access/app_repo_role.tf
@@ -34,7 +34,8 @@ data "aws_iam_policy_document" "push_images" {
       "ecr:InitiateLayerUpload",
       "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
-      "ecr:PutImage"
+      "ecr:PutImage",
+      "ecr:ListImages"
     ]
     resources = [var.ecr_arn]
     effect    = "Allow"


### PR DESCRIPTION
This was required for checking whether an image with a given tag already exists (as part of the aws deploy pipeline).