### PR TITLE
CLDC-2915: Implement load balancer access logging

### DIFF
--- a/terraform/modules/front_door/access_log_bucket.tf
+++ b/terraform/modules/front_door/access_log_bucket.tf
@@ -1,0 +1,91 @@
+#tfsec:ignore:aws-s3-enable-bucket-encryption: access log buckets not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
+#tfsec:ignore:aws-s3-enable-bucket-logging: access log bucket doesn't need access logging itself
+#tfsec:ignore:aws-s3-encryption-customer-key: access log buckets not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
+resource "aws_s3_bucket" "load_balancer_access_logs" {
+  #checkov:skip=CKV2_AWS_62: no need for event notifications
+  #checkov:skip=CKV_AWS_18: access log bucket doesn't need access logging itself
+  #checkov:skip=CKV_AWS_145: access log buckets not compatible with kms encryption, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
+  #checkov:skip=CKV_AWS_144: cross region replication not required for access logs
+  bucket = "${var.prefix}-load-balancer-logs"
+}
+
+resource "aws_s3_bucket_public_access_block" "load_balancer_access_logs" {
+  bucket = aws_s3_bucket.load_balancer_access_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_elb_service_account" "current" {}
+
+resource "aws_s3_bucket_policy" "force_ssl_and_allow_access_logs" {
+  bucket = aws_s3_bucket.load_balancer_access_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowSSLRequestsOnly",
+        Action    = "s3:*",
+        Effect    = "Deny",
+        Principal = "*",
+        Resource = [
+          aws_s3_bucket.load_balancer_access_logs.arn,
+          "${aws_s3_bucket.load_balancer_access_logs.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        },
+        Sid    = "AllowLoadBalancerAccessLogs",
+        Action = "s3:PutObject",
+        Effect = "Allow",
+        Principal = {
+          AWS = data.aws_elb_service_account.current.arn
+        },
+        Resource = [
+          "${aws_s3_bucket.load_balancer_access_logs.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_versioning" "load_balancer_access_logs" {
+  bucket = aws_s3_bucket.load_balancer_access_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "load_balancer_access_logs" {
+  bucket = aws_s3_bucket.load_balancer_access_logs.id
+
+  rule {
+    id     = "expire-old-logs"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
+    expiration {
+      days = 90
+    }
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+  }
+}

--- a/terraform/modules/front_door/access_log_bucket.tf
+++ b/terraform/modules/front_door/access_log_bucket.tf
@@ -39,7 +39,9 @@ resource "aws_s3_bucket_policy" "force_ssl_and_allow_access_logs" {
           Bool = {
             "aws:SecureTransport" = "false"
           }
-        },
+        }
+      },
+      {
         Sid    = "AllowLoadBalancerAccessLogs",
         Action = "s3:PutObject",
         Effect = "Allow",

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -9,6 +9,12 @@ resource "aws_lb" "this" {
   load_balancer_type         = "application"
   security_groups            = [aws_security_group.load_balancer.id]
   subnets                    = var.public_subnet_ids
+
+  access_logs {
+    enabled = true
+    bucket  = aws_s3_bucket.load_balancer_access_logs.id
+    prefix  = ""
+  }
 }
 
 resource "aws_lb_listener" "https" {

--- a/terraform/modules/front_door/load_balancer_access_log_bucket.tf
+++ b/terraform/modules/front_door/load_balancer_access_log_bucket.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket_public_access_block" "load_balancer_access_logs" {
 
 data "aws_elb_service_account" "current" {}
 
-resource "aws_s3_bucket_policy" "force_ssl_and_allow_access_logs" {
+resource "aws_s3_bucket_policy" "force_ssl_and_allow_load_balancer_access_logs" {
   bucket = aws_s3_bucket.load_balancer_access_logs.id
 
   policy = jsonencode({

--- a/terraform/staging/.terraform.lock.hcl
+++ b/terraform/staging/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.19.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:B14fi+fHRJorCabBF2NAx7JpO58qZdve9eZi3zMdp8c=",
     "h1:MJclj56jijp7T4V4g5tzHXS3M8vUdJAcBRjEstBh0Hc=",
     "zh:03aa0f857c6dfce5f46c9bf3aad45534b9421e68983994b6f9dd9812beaece9c",
     "zh:0639818c5bf9f9943667f39ec38bb945c9786983025dff407390133fa1ca5041",


### PR DESCRIPTION
- Enable access logging on the load balancer, with the logs going to a separate dedicated log bucket
- Check the access logs appear in the dedicated bucket ✅