### PR TITLE
CLDC-2907: Remove permissions on default security groups

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -27,6 +27,24 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "eu-west-1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
+  alias  = "eu-west-3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
 
@@ -198,6 +216,12 @@ module "front_door" {
 
 module "networking" {
   source = "../modules/networking"
+
+  providers = {
+    aws.eu-west-1 = aws.eu-west-1
+    aws.eu-west-3 = aws.eu-west-3
+    aws.us-east-1 = aws.us-east-1
+  }
 
   prefix                                  = local.prefix
   vpc_cidr_block                          = "10.0.0.0/16"

--- a/terraform/modules/networking/gateways.tf
+++ b/terraform/modules/networking/gateways.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "this" {
-  vpc_id = aws_vpc.this.id
+  vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "${var.prefix}-internet-gateway"

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -5,6 +5,11 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~>5.0"
+      configuration_aliases = [
+        aws.eu-west-1,
+        aws.eu-west-3,
+        aws.us-east-1
+      ]
     }
   }
 }

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -24,6 +24,6 @@ output "redis_private_subnet_group_name" {
 }
 
 output "vpc_id" {
-  value       = aws_vpc.this.id
+  value       = aws_vpc.main.id
   description = "The id of the main vpc"
 }

--- a/terraform/modules/networking/routing.tf
+++ b/terraform/modules/networking/routing.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.this.id
+  vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "${var.prefix}-public-route-table"
@@ -20,7 +20,7 @@ resource "aws_route_table_association" "public" {
 
 resource "aws_route_table" "private" {
   count  = length(aws_nat_gateway.this)
-  vpc_id = aws_vpc.this.id
+  vpc_id = aws_vpc.main.id
 
   tags = {
     Name = "${var.prefix}-private-route-table-${count.index}"

--- a/terraform/modules/networking/security_groups.tf
+++ b/terraform/modules/networking/security_groups.tf
@@ -1,0 +1,21 @@
+resource "aws_default_security_group" "default-eu-west-2" {
+  vpc_id = data.aws_vpc.default-eu-west-2.id
+}
+
+resource "aws_default_security_group" "default-eu-west-1" {
+  provider = aws.eu-west-1
+
+  vpc_id = data.aws_vpc.default-eu-west-1.id
+}
+
+resource "aws_default_security_group" "default-eu-west-3" {
+  provider = aws.eu-west-3
+
+  vpc_id = data.aws_vpc.default-eu-west-3.id
+}
+
+resource "aws_default_security_group" "default-us-east-1" {
+  provider = aws.us-east-1
+
+  vpc_id = data.aws_vpc.default-us-east-1.id
+}

--- a/terraform/modules/networking/security_groups.tf
+++ b/terraform/modules/networking/security_groups.tf
@@ -2,24 +2,24 @@ resource "aws_default_security_group" "main" {
   vpc_id = aws_vpc.main.id
 }
 
-resource "aws_default_security_group" "default-eu-west-2" {
-  vpc_id = data.aws_vpc.default-eu-west-2.id
+resource "aws_default_security_group" "default_eu_west_2" {
+  vpc_id = data.aws_vpc.default_eu_west_2.id
 }
 
-resource "aws_default_security_group" "default-eu-west-1" {
+resource "aws_default_security_group" "default_eu_west_1" {
   provider = aws.eu-west-1
 
-  vpc_id = data.aws_vpc.default-eu-west-1.id
+  vpc_id = data.aws_vpc.default_eu_west_1.id
 }
 
-resource "aws_default_security_group" "default-eu-west-3" {
+resource "aws_default_security_group" "default_eu_west_3" {
   provider = aws.eu-west-3
 
-  vpc_id = data.aws_vpc.default-eu-west-3.id
+  vpc_id = data.aws_vpc.default_eu_west_3.id
 }
 
-resource "aws_default_security_group" "default-us-east-1" {
+resource "aws_default_security_group" "default_us_east_1" {
   provider = aws.us-east-1
 
-  vpc_id = data.aws_vpc.default-us-east-1.id
+  vpc_id = data.aws_vpc.default_us_east_1.id
 }

--- a/terraform/modules/networking/security_groups.tf
+++ b/terraform/modules/networking/security_groups.tf
@@ -1,3 +1,7 @@
+resource "aws_default_security_group" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
 resource "aws_default_security_group" "default-eu-west-2" {
   vpc_id = data.aws_vpc.default-eu-west-2.id
 }

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -10,7 +10,7 @@ resource "aws_subnet" "public" {
   availability_zone = "${local.region}${local.availability_zones[count.index]}"
   # Splits the public CIDR block into three parts (one for each AZ)
   cidr_block = cidrsubnet(local.public_subnet_cidr, 2, count.index)
-  vpc_id     = aws_vpc.this.id
+  vpc_id     = aws_vpc.main.id
 
   tags = {
     Name = "${var.prefix}-public-subnet-${local.region}${local.availability_zones[count.index]}"
@@ -22,7 +22,7 @@ resource "aws_subnet" "private" {
   availability_zone = "${local.region}${local.availability_zones[count.index]}"
   # Splits the private CIDR block into three parts (one for each AZ)
   cidr_block = cidrsubnet(local.private_subnet_cidr, 2, count.index)
-  vpc_id     = aws_vpc.this.id
+  vpc_id     = aws_vpc.main.id
 
   tags = {
     Name = "${var.prefix}-private-subnet-${local.region}${local.availability_zones[count.index]}"

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -85,23 +85,23 @@ data "aws_iam_policy_document" "vpc_flow_logs_assume_role_permissions" {
   }
 }
 
-data "aws_vpc" "default-eu-west-2" {
+data "aws_vpc" "default_eu_west_2" {
   default = true
 }
 
-data "aws_vpc" "default-eu-west-1" {
+data "aws_vpc" "default_eu_west_1" {
   provider = aws.eu-west-1
 
   default = true
 }
 
-data "aws_vpc" "default-eu-west-3" {
+data "aws_vpc" "default_eu_west_3" {
   provider = aws.eu-west-3
 
   default = true
 }
 
-data "aws_vpc" "default-us-east-1" {
+data "aws_vpc" "default_us_east_1" {
   provider = aws.us-east-1
 
   default = true

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -9,11 +9,6 @@ resource "aws_vpc" "main" {
   }
 }
 
-moved {
-  from = aws_vpc.this
-  to   = aws_vpc.main
-}
-
 resource "aws_flow_log" "vpc_accepted" {
   iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_accepted.arn

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -1,4 +1,4 @@
-resource "aws_vpc" "this" {
+resource "aws_vpc" "main" {
   #checkov:skip=CKV2_AWS_12:we don't think that we should restrict all traffic on the default VPC security group, otherwise our application will be completely isolated
   cidr_block           = var.vpc_cidr_block
   enable_dns_support   = true
@@ -9,18 +9,23 @@ resource "aws_vpc" "this" {
   }
 }
 
+moved {
+  from = aws_vpc.this
+  to   = aws_vpc.main
+}
+
 resource "aws_flow_log" "vpc_accepted" {
   iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_accepted.arn
   traffic_type    = "ACCEPT"
-  vpc_id          = aws_vpc.this.id
+  vpc_id          = aws_vpc.main.id
 }
 
 resource "aws_flow_log" "vpc_rejected" {
   iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
   log_destination = aws_cloudwatch_log_group.vpc_flow_logs_rejected.arn
   traffic_type    = "REJECT"
-  vpc_id          = aws_vpc.this.id
+  vpc_id          = aws_vpc.main.id
 }
 
 # tfsec:ignore:aws-cloudwatch-log-group-customer-key:flow logs are non-sensitive

--- a/terraform/modules/networking/vpc.tf
+++ b/terraform/modules/networking/vpc.tf
@@ -84,3 +84,25 @@ data "aws_iam_policy_document" "vpc_flow_logs_assume_role_permissions" {
     ]
   }
 }
+
+data "aws_vpc" "default-eu-west-2" {
+  default = true
+}
+
+data "aws_vpc" "default-eu-west-1" {
+  provider = aws.eu-west-1
+
+  default = true
+}
+
+data "aws_vpc" "default-eu-west-3" {
+  provider = aws.eu-west-3
+
+  default = true
+}
+
+data "aws_vpc" "default-us-east-1" {
+  provider = aws.us-east-1
+
+  default = true
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -406,6 +406,11 @@ module "networking" {
   vpc_flow_cloudwatch_log_expiration_days = 60
 }
 
+moved {
+  from = module.networking.aws_vpc.this
+  to   = module.networking.aws_vpc.main
+}
+
 module "monitoring" {
   source = "../modules/monitoring"
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -27,6 +27,24 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "eu-west-1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
+  alias  = "eu-west-3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
 
@@ -400,6 +418,12 @@ module "front_door" {
 
 module "networking" {
   source = "../modules/networking"
+
+  providers = {
+    aws.eu-west-1 = aws.eu-west-1
+    aws.eu-west-3 = aws.eu-west-3
+    aws.us-east-1 = aws.us-east-1
+  }
 
   prefix                                  = local.prefix
   vpc_cidr_block                          = "10.0.0.0/16"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -27,6 +27,24 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "eu-west-1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
+  alias  = "eu-west-3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = local.provider_role_arn
+  }
+}
+
+provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
 
@@ -243,6 +261,12 @@ module "front_door" {
 
 module "networking" {
   source = "../modules/networking"
+
+  providers = {
+    aws.eu-west-1 = aws.eu-west-1
+    aws.eu-west-3 = aws.eu-west-3
+    aws.us-east-1 = aws.us-east-1
+  }
 
   prefix                                  = local.prefix
   vpc_cidr_block                          = "10.0.0.0/16"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -273,6 +273,11 @@ module "networking" {
   vpc_flow_cloudwatch_log_expiration_days = 60
 }
 
+moved {
+  from = module.networking.aws_vpc.this
+  to   = module.networking.aws_vpc.main
+}
+
 module "monitoring" {
   source = "../modules/monitoring"
 


### PR DESCRIPTION
This task involved 2 parts:
- Explicitly referencing the default VPC security groups
  - There are 4 of these: 3 for eu-west-x and 1 for us-east-1 (these were the VPCs called out in the pen test matrix, but we already knew that these are the only regions which we have permission to create resources in)
- "Adopting" into our terraform state the default security group for each of these VPCs, as well as the non-default VPC we have been using so far in the project.