### PR TITLE
CLDC-2608: Deploy Production Updates

### DIFF
--- a/docs/environment_creation_from_scratch.md
+++ b/docs/environment_creation_from_scratch.md
@@ -1,24 +1,21 @@
 # Creating a new environment from scratch
 
-TODO: Update this once splitting out secrets and app roles is done, add instructions for sorting those and things to update in meta.
-
-When setting up a new environment;
+When setting up a new environment:
 1. DNS records will need to be created by DLUHC for certificate validation and to point at the cloudfront distribution and app load balancer
 1. Secret values will need to be filled in manually
-1. Need to set up deployments etc.
-1. Need to ensure anything that needs adding to the meta module (e.g. for roles access to ecr) is done, since some of that is currently manual
+1. The meta account will need updating with additional roles access to the ecr, since this is currently manual
+1. A new deployment pipeline will need to be setup
 
 ## The process
 
 ### Run an initial apply
 
-```terraform apply -target="module.networking" -target="module.front_door" -var="initial_create=true"```
+```terraform apply -target="module.networking" -target="module.front_door" -target="module.certificates" --target="module.application_roles" --target="module.application_secrets" var="initial_create=true"```
 
 (Need the networking explicitly otherwise we get an error creating the load balancer, there's some kind of dependency that terraform doesn't quite get)
 
-This will create the certificates, load balancer, cloudfront distribution, and some networking and other things.
-
-Potentially also do the secrets at this point (once they are pulled out of the application module) since they also have a manual step, so you can fill them out before the app itself is created and tries to read them.
+This will create the certificates, load balancer, cloudfront distribution, and some networking and other things needed for defining DNS records.
+It will also create some app roles and secrets which are necessary before creating the full app.
 
 ### Get DNS Records set up
 
@@ -30,6 +27,17 @@ This will be;
 * CNAME for the cloudfront domain pointing at the cloudfront distribution
 * CNAME for the load balancer domain pointing at the load balancer
 
+Once DLUHC has set up the records, check the certificates have been validated in AWS console.
+
+### Fill the application secrets
+
+When doing a full apply the complete application will be created, and will need to be able to read secrets. 
+Fill out the values for the secrets in AWS console before the full apply.
+
+### Update meta environment
+
+In the [meta/main.tf](../terraform/meta/main.tf) file, add the ARN of the task-execution role from the newly created environment to the ECR module's `allow_access_by_roles` parameter
+
 ### Run a full apply
 
 Once these have been done, run a complete apply
@@ -39,3 +47,8 @@ Once these have been done, run a complete apply
 If not restoring the database from a backup, or migrating it from elsewhere, run the db:setup rake task (use the ad_hoc task definition to spin it up from the app image with a command override).
 
 Alternatively you probably need to run an app deployment to sort out using the right image, which will include a db migration - you can then just run db:seed as a separate task.
+
+### Set up the deployment
+
+In the Core App codebase [here](https://github.com/communitiesuk/submit-social-housing-lettings-and-sales-data), you will need create a new pipeline for the environment (you can re-use jobs and configuration in existing pipelines where appropriate)
+For the `aws_deploy` workflow, ensure you pass in the new account id, resource prefix and environment name

--- a/docs/environment_creation_from_scratch.md
+++ b/docs/environment_creation_from_scratch.md
@@ -10,7 +10,7 @@ When setting up a new environment:
 
 ### Run an initial apply
 
-```terraform apply -target="module.networking" -target="module.front_door" -target="module.certificates" --target="module.application_roles" --target="module.application_secrets" var="initial_create=true"```
+```terraform apply -target="module.networking" -target="module.front_door" -target="module.application_secrets" -var="initial_create=true"```
 
 (Need the networking explicitly otherwise we get an error creating the load balancer, there's some kind of dependency that terraform doesn't quite get)
 

--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -68,7 +68,6 @@ module "application" {
   ecr_repository_url = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
 
   prefix                                            = local.prefix
-  api_key_secret_arn                                = data.terraform_remote_state.development_shared.outputs.application_secrets_api_key_secret_arn
   app_host                                          = local.app_host
   app_task_desired_count                            = local.app_task_desired_count
   application_port                                  = local.application_port

--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -79,7 +79,6 @@ module "application_roles" {
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
 
   secret_arns = [
-    module.application_secrets.api_key_secret_arn,
     module.application_secrets.govuk_notify_api_key_secret_arn,
     module.application_secrets.os_data_key_secret_arn,
     module.application_secrets.rails_master_key_secret_arn,

--- a/terraform/development/shared/outputs.tf
+++ b/terraform/development/shared/outputs.tf
@@ -18,11 +18,6 @@ output "application_roles_ecs_task_role_arn" {
   description = "The arn of the ecs task role"
 }
 
-output "application_secrets_api_key_secret_arn" {
-  value       = module.application_secrets.api_key_secret_arn
-  description = "The arn of the api key secret"
-}
-
 output "application_secrets_govuk_notify_api_key_secret_arn" {
   value       = module.application_secrets.govuk_notify_api_key_secret_arn
   description = "The arn of the govuk notify api key secret"

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -36,7 +36,6 @@ resource "aws_ecs_task_definition" "app" {
     {
       name = local.app_container_name
       environment = [
-        { Name = "API_USER", Value = "dluhc-user" },
         { Name = "APP_HOST", Value = var.app_host },
         { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
         { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
@@ -70,7 +69,6 @@ resource "aws_ecs_task_definition" "app" {
       ]
 
       secrets = [
-        { Name = "API_KEY", valueFrom = var.api_key_secret_arn },
         { Name = "DATABASE_URL", valueFrom = aws_ssm_parameter.complete_database_connection_string.arn },
         { Name = "GOVUK_NOTIFY_API_KEY", valueFrom = var.govuk_notify_api_key_secret_arn },
         { Name = "OS_DATA_KEY", valueFrom = var.os_data_key_secret_arn },
@@ -108,7 +106,6 @@ resource "aws_ecs_task_definition" "sidekiq" {
       name    = local.sidekiq_container_name
       command = ["bundle", "exec", "sidekiq", "-t", "3"]
       environment = [
-        { Name = "API_USER", Value = "dluhc-user" },
         { Name = "APP_HOST", Value = var.app_host },
         { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
         { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
@@ -134,7 +131,6 @@ resource "aws_ecs_task_definition" "sidekiq" {
       }
 
       secrets = [
-        { Name = "API_KEY", valueFrom = var.api_key_secret_arn },
         { Name = "DATABASE_URL", valueFrom = aws_ssm_parameter.complete_database_connection_string.arn },
         { Name = "GOVUK_NOTIFY_API_KEY", valueFrom = var.govuk_notify_api_key_secret_arn },
         { Name = "OS_DATA_KEY", valueFrom = var.os_data_key_secret_arn },
@@ -171,7 +167,6 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
     {
       name = local.app_container_name
       environment = [
-        { Name = "API_USER", Value = "dluhc-user" },
         { Name = "APP_HOST", Value = var.app_host },
         { Name = "CSV_DOWNLOAD_PAAS_INSTANCE", Value = local.bulk_upload_bucket_key },
         { Name = "EXPORT_PAAS_INSTANCE", Value = local.export_bucket_key },
@@ -205,7 +200,6 @@ resource "aws_ecs_task_definition" "ad_hoc_tasks" {
       ]
 
       secrets = [
-        { Name = "API_KEY", valueFrom = var.api_key_secret_arn },
         { Name = "DATABASE_URL", valueFrom = aws_ssm_parameter.complete_database_connection_string.arn },
         { Name = "GOVUK_NOTIFY_API_KEY", valueFrom = var.govuk_notify_api_key_secret_arn },
         { Name = "OS_DATA_KEY", valueFrom = var.os_data_key_secret_arn },

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -1,8 +1,3 @@
-variable "api_key_secret_arn" {
-  type        = string
-  description = "The arn of the api key secret"
-}
-
 variable "app_host" {
   type        = string
   description = "The value of the app host environment variable"

--- a/terraform/modules/application_secrets/outputs.tf
+++ b/terraform/modules/application_secrets/outputs.tf
@@ -1,8 +1,3 @@
-output "api_key_secret_arn" {
-  value       = aws_secretsmanager_secret.api_key.arn
-  description = "The arn of the api key secret"
-}
-
 output "govuk_notify_api_key_secret_arn" {
   value       = aws_secretsmanager_secret.govuk_notify_api_key.arn
   description = "The arn of the govuk notify api key secret"

--- a/terraform/modules/application_secrets/secrets.tf
+++ b/terraform/modules/application_secrets/secrets.tf
@@ -1,9 +1,3 @@
-resource "aws_secretsmanager_secret" "api_key" {
-  #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
-  name       = "API_KEY"
-  kms_key_id = aws_kms_key.this.arn
-}
-
 resource "aws_secretsmanager_secret" "govuk_notify_api_key" {
   #checkov:skip=CKV2_AWS_57:secret is fixed, can't be automatically rotated
   name       = "GOVUK_NOTIFY_API_KEY"

--- a/terraform/production/.terraform.lock.hcl
+++ b/terraform/production/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.19.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:B14fi+fHRJorCabBF2NAx7JpO58qZdve9eZi3zMdp8c=",
     "h1:MJclj56jijp7T4V4g5tzHXS3M8vUdJAcBRjEstBh0Hc=",
     "zh:03aa0f857c6dfce5f46c9bf3aad45534b9421e68983994b6f9dd9812beaece9c",
     "zh:0639818c5bf9f9943667f39ec38bb945c9786983025dff407390133fa1ca5041",

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -90,7 +90,6 @@ module "application" {
   ecr_repository_url = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
 
   prefix                                            = local.prefix
-  api_key_secret_arn                                = module.application_secrets.api_key_secret_arn
   app_host                                          = local.app_host
   app_task_desired_count                            = local.app_task_desired_count
   application_port                                  = local.application_port
@@ -131,7 +130,6 @@ module "application_roles" {
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
 
   secret_arns = [
-    module.application_secrets.api_key_secret_arn,
     module.application_secrets.govuk_notify_api_key_secret_arn,
     module.application_secrets.os_data_key_secret_arn,
     module.application_secrets.rails_master_key_secret_arn,

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -77,41 +77,6 @@ locals {
   create_s3_migration_infra = false
 }
 
-moved {
-  from = module.application.aws_iam_policy.ecs_tasks_and_services
-  to   = module.application.aws_iam_policy.run_ecs_task_and_update_service
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.ecs_tasks_and_services
-  to   = module.application.aws_iam_role_policy_attachment.run_ecs_task_and_update_service
-}
-
-moved {
-  from = module.front_door.aws_lb_target_group.this
-  to   = module.application.aws_lb_target_group.this
-}
-
-moved {
-  from = module.front_door.aws_lb_listener_rule.forward_cloudfront
-  to   = module.application.aws_lb_listener_rule.forward_cloudfront
-}
-
-moved {
-  from = module.front_door.aws_cloudwatch_metric_alarm.healthy_hosts_count
-  to   = module.application.aws_cloudwatch_metric_alarm.healthy_hosts_count
-}
-
-moved {
-  from = module.front_door.aws_cloudwatch_metric_alarm.unhealthy_hosts_count
-  to   = module.application.aws_cloudwatch_metric_alarm.unhealthy_hosts_count
-}
-
-moved {
-  from = module.application_roles.aws_iam_role_policy.parameter_access
-  to   = module.application.aws_iam_role_policy.parameter_access
-}
-
 module "application" {
   source = "../modules/application"
 
@@ -151,63 +116,9 @@ module "application" {
   sentry_dsn_secret_arn                             = module.application_secrets.sentry_dsn_secret_arn
   sns_topic_arn                                     = module.monitoring.sns_topic_arn
   vpc_id                                            = module.networking.vpc_id
-}
 
-moved {
-  from = module.application.aws_iam_role.task
-  to   = module.application_roles.aws_iam_role.task
+  depends_on = [module.database.rds_partial_connection_string_parameter_name]
 }
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.ecs_task_database_data_access
-  to   = module.application_roles.aws_iam_role_policy_attachment.ecs_task_database_data_access
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.ecs_task_redis_access
-  to   = module.application_roles.aws_iam_role_policy_attachment.ecs_task_redis_access
-}
-
-moved {
-  from = module.application.aws_iam_role_policy.cloudwatch_logs_access
-  to   = module.application_roles.aws_iam_role_policy.cloudwatch_logs_access
-}
-
-moved {
-  from = module.application.aws_iam_policy.allow_ecs_exec
-  to   = module.application_roles.aws_iam_policy.allow_ecs_exec
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.task_allow_ecs_exec
-  to   = module.application_roles.aws_iam_role_policy_attachment.task_allow_ecs_exec
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.task_bulk_upload_bucket_access
-  to   = module.application_roles.aws_iam_role_policy_attachment.task_bulk_upload_bucket_access
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.task_export_bucket_access
-  to   = module.application_roles.aws_iam_role_policy_attachment.task_export_bucket_access
-}
-
-moved {
-  from = module.application.aws_iam_role.task_execution
-  to   = module.application_roles.aws_iam_role.task_execution
-}
-
-moved {
-  from = module.application.aws_iam_role_policy_attachment.task_execution_managed_policy
-  to   = module.application_roles.aws_iam_role_policy_attachment.task_execution_managed_policy
-}
-
-moved {
-  from = module.application.aws_iam_role_policy.secret_access
-  to   = module.application_roles.aws_iam_role_policy.secret_access
-}
-
 
 module "application_roles" {
   source = "../modules/application_roles"
@@ -226,41 +137,6 @@ module "application_roles" {
     module.application_secrets.rails_master_key_secret_arn,
     module.application_secrets.sentry_dsn_secret_arn
   ]
-}
-
-moved {
-  from = module.application.aws_secretsmanager_secret.api_key
-  to   = module.application_secrets.aws_secretsmanager_secret.api_key
-}
-
-moved {
-  from = module.application.aws_secretsmanager_secret.govuk_notify_api_key
-  to   = module.application_secrets.aws_secretsmanager_secret.govuk_notify_api_key
-}
-
-moved {
-  from = module.application.aws_secretsmanager_secret.os_data_key
-  to   = module.application_secrets.aws_secretsmanager_secret.os_data_key
-}
-
-moved {
-  from = module.application.aws_secretsmanager_secret.rails_master_key
-  to   = module.application_secrets.aws_secretsmanager_secret.rails_master_key
-}
-
-moved {
-  from = module.application.aws_secretsmanager_secret.sentry_dsn
-  to   = module.application_secrets.aws_secretsmanager_secret.sentry_dsn
-}
-
-moved {
-  from = module.redis.aws_security_group.this
-  to   = module.application_security_group.aws_security_group.redis
-}
-
-moved {
-  from = module.redis.aws_vpc_security_group_ingress_rule.redis_ingress
-  to   = module.application_security_group.aws_vpc_security_group_ingress_rule.redis_ingress
 }
 
 module "application_secrets" {
@@ -282,41 +158,11 @@ module "application_security_group" {
   vpc_id                          = module.networking.vpc_id
 }
 
-moved {
-  from = module.bulk_upload.aws_s3_bucket.this
-  to   = module.bulk_upload.aws_s3_bucket.bulk_upload
-}
-
-moved {
-  from = module.bulk_upload.aws_s3_bucket_public_access_block.this
-  to   = module.bulk_upload.aws_s3_bucket_public_access_block.bulk_upload
-}
-
-moved {
-  from = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.this
-  to   = module.bulk_upload.aws_s3_bucket_lifecycle_configuration.bulk_upload
-}
-
 module "bulk_upload" {
   source = "../modules/bulk_upload"
 
   prefix            = local.prefix
   ecs_task_role_arn = module.application_roles.ecs_task_role_arn
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket.this
-  to   = module.cds_export.aws_s3_bucket.export
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket_public_access_block.this
-  to   = module.cds_export.aws_s3_bucket_public_access_block.export
-}
-
-moved {
-  from = module.cds_export.aws_s3_bucket_lifecycle_configuration.this
-  to   = module.cds_export.aws_s3_bucket_lifecycle_configuration.export
 }
 
 module "cds_export" {
@@ -340,11 +186,6 @@ module "certificates" {
 
   cloudfront_domain_name    = local.app_host
   load_balancer_domain_name = local.load_balancer_domain_name
-}
-
-moved {
-  from = module.database.aws_ssm_parameter.database_connection_string
-  to   = module.database.aws_ssm_parameter.database_partial_connection_string
 }
 
 module "database" {
@@ -453,11 +294,6 @@ module "networking" {
   prefix                                  = local.prefix
   vpc_cidr_block                          = "10.0.0.0/16"
   vpc_flow_cloudwatch_log_expiration_days = 60
-}
-
-moved {
-  from = module.networking.aws_vpc.this
-  to   = module.networking.aws_vpc.main
 }
 
 module "monitoring" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -121,6 +121,8 @@ module "application" {
   sentry_dsn_secret_arn                             = module.application_secrets.sentry_dsn_secret_arn
   sns_topic_arn                                     = module.monitoring.sns_topic_arn
   vpc_id                                            = module.networking.vpc_id
+
+  depends_on = [module.database.rds_partial_connection_string_parameter_name]
 }
 
 module "application_roles" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -90,7 +90,6 @@ module "application" {
   ecr_repository_url = "815624722760.dkr.ecr.eu-west-2.amazonaws.com/core"
 
   prefix                                            = local.prefix
-  api_key_secret_arn                                = module.application_secrets.api_key_secret_arn
   app_host                                          = local.app_host
   app_task_desired_count                            = local.app_task_desired_count
   application_port                                  = local.application_port
@@ -131,7 +130,6 @@ module "application_roles" {
   export_bucket_access_policy_arn      = module.cds_export.read_write_policy_arn
 
   secret_arns = [
-    module.application_secrets.api_key_secret_arn,
     module.application_secrets.govuk_notify_api_key_secret_arn,
     module.application_secrets.os_data_key_secret_arn,
     module.application_secrets.rails_master_key_secret_arn,


### PR DESCRIPTION
- Remove no longer required terraform moved blocks from Production
- Add a depends_on terraform statement to make apply commands smoother (in staging and prod)
- Update the docs about creating a new env from scratch
- Update the prod lock file for convenience