### PR TITLE
CLDC-2921: SNS email subscriptions

### DIFF
--- a/docs/environment_creation_from_scratch.md
+++ b/docs/environment_creation_from_scratch.md
@@ -38,6 +38,15 @@ Fill out the values for the secrets in AWS console before the full apply.
 
 In the [meta/main.tf](../terraform/meta/main.tf) file, add the ARN of the task-execution role from the newly created environment to the ECR module's `allow_access_by_roles` parameter
 
+### Create and set certain secrets which other infrastructure depends on
+
+At this point, running terraform apply will fail because there are some resources which depend on the value of a secret which hasn't been set yet (because the secret would also be created as part of this apply if the steps below aren't followed).
+
+At the moment the only resource in this situation is the SNS email subscription. If you don't need that subscription for this environment then make sure `create_email_subscription` is set to false in the monitoring module in the environment entrypoint module. You can ignore the rest of this section and move on to running a full apply. However if you do need that subscription then:
+- Make sure `create_email_subscription` is set to true in the monitoring module in the environment entrypoint module
+- Run ```terraform apply -target="module.monitoring" -var="create_secrets_first=true"``` (this will create the `MONITORING_EMAIL` secret)
+- Set the value of the secret (i.e. the email address you want monitoring alerts to go to) in the AWS console (do so as plaintext, and don't keep the curly braces or add quotation marks or any other punctuation)
+
 ### Run a full apply
 
 Once these have been done, run a complete apply

--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -183,6 +183,8 @@ module "monitoring" {
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
+
+  create_secrets_first = var.create_secrets_first
 }
 
 module "networking" {

--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -179,6 +179,8 @@ module "front_door" {
 module "monitoring" {
   source = "../../modules/monitoring"
 
+  create_email_subscription = false
+
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
 }

--- a/terraform/development/shared/variables.tf
+++ b/terraform/development/shared/variables.tf
@@ -1,3 +1,9 @@
+variable "create_secrets_first" {
+  type        = bool
+  description = "Setting to true will avoid creating any infrastructure for which a terraform apply would fail if certain secret values are not set"
+  default     = false
+}
+
 variable "initial_create" {
   type        = bool
   description = "Set to true during an initial apply in a new environment, to avoid cloudfront referencing certificates before they've been validated manually"

--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -104,6 +104,8 @@ module "ecr_s3_migration" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  create_email_subscription = true
+
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "events.amazonaws.com"
 }

--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -108,6 +108,8 @@ module "monitoring" {
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "events.amazonaws.com"
+
+  create_secrets_first = var.create_secrets_first
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/meta/variables.tf
+++ b/terraform/meta/variables.tf
@@ -1,0 +1,5 @@
+variable "create_secrets_first" {
+  type        = bool
+  description = "Setting to true will avoid creating any infrastructure for which a terraform apply would fail if certain secret values are not set"
+  default     = false
+}

--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -1,27 +1,19 @@
 resource "aws_kms_key" "this" {
-  count = var.create_email_subscription ? 1 : 0
-
   description         = "KMS key used to decrypt the Secrets Manager secrets."
   enable_key_rotation = true
 }
 
 resource "aws_kms_alias" "this" {
-  count = var.create_email_subscription ? 1 : 0
-
   name          = "alias/${var.prefix}-monitoring-secretsmanager-secrets"
-  target_key_id = aws_kms_key.this[0].key_id
+  target_key_id = aws_kms_key.this.key_id
 }
 
 resource "aws_kms_key_policy" "this" {
-  count = var.create_email_subscription ? 1 : 0
-
-  key_id = aws_kms_key.this[0].id
-  policy = data.aws_iam_policy_document.kms[0].json
+  key_id = aws_kms_key.this.id
+  policy = data.aws_iam_policy_document.kms.json
 }
 
 data "aws_iam_policy_document" "kms" {
-  count = var.create_email_subscription ? 1 : 0
-
   statement {
     principals {
       type        = "AWS"
@@ -30,6 +22,6 @@ data "aws_iam_policy_document" "kms" {
 
     actions = ["kms:*"]
 
-    resources = [aws_kms_key.this[0].arn]
+    resources = [aws_kms_key.this.arn]
   }
 }

--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -1,0 +1,38 @@
+resource "aws_kms_key" "this" {
+  description         = "KMS key used to decrypt the Secrets Manager secrets."
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.prefix}-monitoring-secretsmanager-secrets"
+  target_key_id = aws_kms_key.this.key_id
+}
+
+resource "aws_kms_key_policy" "this" {
+  key_id = aws_kms_key.this.id
+  policy = data.aws_iam_policy_document.kms.json
+}
+
+data "aws_iam_policy_document" "kms" {
+  # statement {
+  #   principals {
+  #     type        = "AWS"
+  #     identifiers = [var.ecs_task_execution_role_arn]
+  #   }
+
+  #   actions = ["kms:Decrypt"]
+
+  #   resources = [aws_kms_key.this.arn]
+  # }
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions = ["kms:*"]
+
+    resources = [aws_kms_key.this.arn]
+  }
+}

--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -1,19 +1,27 @@
 resource "aws_kms_key" "this" {
+  count = var.create_email_subscription ? 1 : 0
+
   description         = "KMS key used to decrypt the Secrets Manager secrets."
   enable_key_rotation = true
 }
 
 resource "aws_kms_alias" "this" {
+  count = var.create_email_subscription ? 1 : 0
+
   name          = "alias/${var.prefix}-monitoring-secretsmanager-secrets"
-  target_key_id = aws_kms_key.this.key_id
+  target_key_id = aws_kms_key.this[0].key_id
 }
 
 resource "aws_kms_key_policy" "this" {
-  key_id = aws_kms_key.this.id
-  policy = data.aws_iam_policy_document.kms.json
+  count = var.create_email_subscription ? 1 : 0
+
+  key_id = aws_kms_key.this[0].id
+  policy = data.aws_iam_policy_document.kms[0].json
 }
 
 data "aws_iam_policy_document" "kms" {
+  count = var.create_email_subscription ? 1 : 0
+
   statement {
     principals {
       type        = "AWS"
@@ -22,6 +30,6 @@ data "aws_iam_policy_document" "kms" {
 
     actions = ["kms:*"]
 
-    resources = [aws_kms_key.this.arn]
+    resources = [aws_kms_key.this[0].arn]
   }
 }

--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -14,17 +14,6 @@ resource "aws_kms_key_policy" "this" {
 }
 
 data "aws_iam_policy_document" "kms" {
-  # statement {
-  #   principals {
-  #     type        = "AWS"
-  #     identifiers = [var.ecs_task_execution_role_arn]
-  #   }
-
-  #   actions = ["kms:Decrypt"]
-
-  #   resources = [aws_kms_key.this.arn]
-  # }
-
   statement {
     principals {
       type        = "AWS"

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -7,7 +7,7 @@ resource "aws_secretsmanager_secret" "email" {
 }
 
 data "aws_secretsmanager_secret_version" "email" {
-  count = var.create_email_subscription ? 1 : 0
+  count = var.create_email_subscription && !var.create_secrets_first ? 1 : 0
 
   secret_id = aws_secretsmanager_secret.email[0].arn
 }

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,13 +1,11 @@
 resource "aws_secretsmanager_secret" "email" {
-  count = var.create_email_subscription ? 1 : 0
-
   #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
   name       = "MONITORING_EMAIL"
-  kms_key_id = aws_kms_key.this[0].arn
+  kms_key_id = aws_kms_key.this.arn
 }
 
 data "aws_secretsmanager_secret_version" "email" {
-  count = var.create_email_subscription ? 1 : 0
+  count = var.create_secrets_first ? 0 : 1
 
-  secret_id = aws_secretsmanager_secret.email[0].arn
+  secret_id = aws_secretsmanager_secret.email.arn
 }

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,0 +1,5 @@
+resource "aws_secretsmanager_secret" "email" {
+  #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
+  name       = "MONITORING_EMAIL"
+  kms_key_id = aws_kms_key.this.arn
+}

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "email" {
   #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
   name       = "MONITORING_EMAIL"
-  # kms_key_id = aws_kms_key.this.arn
+  kms_key_id = aws_kms_key.this.arn
 }
 
 data "aws_secretsmanager_secret_version" "email" {

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,9 +1,13 @@
 resource "aws_secretsmanager_secret" "email" {
+  count = var.create_email_subscription ? 1 : 0
+
   #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
   name       = "MONITORING_EMAIL"
-  kms_key_id = aws_kms_key.this.arn
+  kms_key_id = aws_kms_key.this[0].arn
 }
 
 data "aws_secretsmanager_secret_version" "email" {
-  secret_id = aws_secretsmanager_secret.email.arn
+  count = var.create_email_subscription ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.email[0].arn
 }

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,11 +1,13 @@
 resource "aws_secretsmanager_secret" "email" {
+  count = var.create_email_subscription ? 1 : 0
+
   #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
   name       = "MONITORING_EMAIL"
-  kms_key_id = aws_kms_key.this.arn
+  kms_key_id = aws_kms_key.this[0].arn
 }
 
 data "aws_secretsmanager_secret_version" "email" {
-  count = var.create_secrets_first ? 0 : 1
+  count = var.create_email_subscription ? 1 : 0
 
-  secret_id = aws_secretsmanager_secret.email.arn
+  secret_id = aws_secretsmanager_secret.email[0].arn
 }

--- a/terraform/modules/monitoring/secrets.tf
+++ b/terraform/modules/monitoring/secrets.tf
@@ -1,5 +1,9 @@
 resource "aws_secretsmanager_secret" "email" {
   #checkov:skip=CKV2_AWS_57:secret doesn't require automatic rotation
   name       = "MONITORING_EMAIL"
-  kms_key_id = aws_kms_key.this.arn
+  # kms_key_id = aws_kms_key.this.arn
+}
+
+data "aws_secretsmanager_secret_version" "email" {
+  secret_id = aws_secretsmanager_secret.email.arn
 }

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic_subscription" "email" {
-  count = var.create_email_subscription ? 1 : 0
+  count = var.create_email_subscription && !var.create_secrets_first ? 1 : 0
 
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,0 +1,5 @@
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.this.arn
+  protocol  = "email"
+  endpoint  = aws_secretsmanager_secret.email.arn
+}

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic_subscription" "email" {
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"
-  endpoint  = aws_secretsmanager_secret.email.arn
+  endpoint  = data.aws_secretsmanager_secret_version.email.secret_string
 }

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic_subscription" "email" {
-  count = var.create_secrets_first ? 0 : 1
+  count = var.create_email_subscription ? 1 : 0
 
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,5 +1,7 @@
 resource "aws_sns_topic_subscription" "email" {
+  count = var.create_email_subscription ? 1 : 0
+
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"
-  endpoint  = data.aws_secretsmanager_secret_version.email.secret_string
+  endpoint  = data.aws_secretsmanager_secret_version.email[0].secret_string
 }

--- a/terraform/modules/monitoring/subscriptions.tf
+++ b/terraform/modules/monitoring/subscriptions.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic_subscription" "email" {
-  count = var.create_email_subscription ? 1 : 0
+  count = var.create_secrets_first ? 0 : 1
 
   topic_arn = aws_sns_topic.this.arn
   protocol  = "email"

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,3 +1,8 @@
+variable "create_email_subscription" {
+  type        = bool
+  description = "Setting to true will create an email subscription for infrastructure monitoring alerts."
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to be prepended to resource names."

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,6 +1,6 @@
-variable "create_email_subscription" {
+variable "create_secrets_first" {
   type        = bool
-  description = "Setting to true will create an email subscription for infrastructure monitoring alerts."
+  description = "Setting to true will avoid creating the email subscription (and any other infra) for which a terraform apply would fail if the value of certain secrets were not set."
 }
 
 variable "prefix" {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -3,6 +3,11 @@ variable "create_email_subscription" {
   description = "Setting to true will create an email subscription for infrastructure monitoring alerts."
 }
 
+variable "create_secrets_first" {
+  type        = bool
+  description = "Setting to true will avoid creating the email subscription (and any other infra) for which a terraform apply would fail if the value of certain secrets were not set."
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to be prepended to resource names."

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,6 +1,6 @@
-variable "create_secrets_first" {
+variable "create_email_subscription" {
   type        = bool
-  description = "Setting to true will avoid creating the email subscription (and any other infra) for which a terraform apply would fail if the value of certain secrets were not set."
+  description = "Setting to true will create an email subscription for infrastructure monitoring alerts."
 }
 
 variable "prefix" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -302,6 +302,8 @@ module "monitoring" {
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
+
+  create_secrets_first = var.create_secrets_first
 }
 
 module "redis" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -463,6 +463,8 @@ moved {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  create_email_subscription = true
+
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
 }

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -1,3 +1,9 @@
+variable "create_secrets_first" {
+  type        = bool
+  description = "Setting to true will avoid creating any infrastructure for which a terraform apply would fail if certain secret values are not set"
+  default     = false
+}
+
 variable "initial_create" {
   type        = bool
   description = "Set to true during an initial apply in a new environment, to avoid cloudfront referencing certificates before they've been validated manually"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -300,6 +300,8 @@ module "monitoring" {
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
+
+  create_secrets_first = var.create_secrets_first
 }
 
 module "redis" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -296,7 +296,7 @@ module "networking" {
 module "monitoring" {
   source = "../modules/monitoring"
 
-  create_secrets_first = var.create_secrets_first
+  create_email_subscription = false
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -296,7 +296,7 @@ module "networking" {
 module "monitoring" {
   source = "../modules/monitoring"
 
-  create_email_subscription = false
+  create_secrets_first = var.create_secrets_first
 
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -295,6 +295,8 @@ module "networking" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  create_email_subscription = false
+
   prefix                               = local.prefix
   service_identifier_publishing_to_sns = "cloudwatch.amazonaws.com"
 }

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,3 +1,9 @@
+variable "create_secrets_first" {
+  type        = bool
+  description = "Setting to true will avoid creating any infrastructure for which a terraform apply would fail if certain secret values are not set"
+  default     = false
+}
+
 variable "initial_create" {
   type        = bool
   description = "Set to true during an initial apply in a new environment, to avoid cloudfront referencing certificates before they've been validated manually"

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,9 +1,3 @@
-variable "create_secrets_first" {
-  type        = bool
-  description = "Setting to true will avoid creating any infrastructure for which a terraform apply would fail if certain secret values are not set"
-  default     = false
-}
-
 variable "initial_create" {
   type        = bool
   description = "Set to true during an initial apply in a new environment, to avoid cloudfront referencing certificates before they've been validated manually"


### PR DESCRIPTION
I've tested this and it works. The team DL email address is saved in secrets manager, and I've just updated the team DL to include Rachael, Chirag and myself (this can easily be updated via HYP of course).

I've added some docs [here](https://dluhcdigital.atlassian.net/l/cp/wcf0bRKp) about the fact that when applying a new subscription in an environment, you'll get an error if you haven't already created the secret using `terraform apply -target="module.monitoring" -var="create_secrets_first=true"` and also set its value. There is a more comprehensive guide on this in `docs/environment_creation_from_scratch.md`.