### PR TITLE
CLDC-2559: Test backup and restore procedures

### DIFF
--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -139,6 +139,7 @@ module "database" {
 
   apply_changes_immediately          = true
   enable_primary_deletion_protection = true
+  enable_replica_deletion_protection = true
   highly_available                   = false
   skip_final_snapshot                = true
   instance_class                     = "db.m5.xlarge"

--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -10,6 +10,7 @@ resource "aws_elasticache_replication_group" "this" {
   description                 = "Redis replication group, consisting of a single node, or a primary node and a replica."
   engine                      = "redis"
   engine_version              = "6.2"
+  final_snapshot_identifier   = var.prefix
   maintenance_window          = "sun:23:00-mon:01:30"
   multi_az_enabled            = var.highly_available ? true : false
   node_type                   = var.node_type

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -51,14 +51,12 @@ resource "aws_db_instance" "replica" {
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
   deletion_protection        = true
-  final_snapshot_identifier  = aws_db_instance.this.final_snapshot_identifier
   instance_class             = aws_db_instance.this.instance_class
   maintenance_window         = aws_db_instance.this.maintenance_window
   multi_az                   = aws_db_instance.this.multi_az
   port                       = aws_db_instance.this.port
   publicly_accessible        = aws_db_instance.this.publicly_accessible
   replicate_source_db        = aws_db_instance.this.identifier
-  skip_final_snapshot        = aws_db_instance.this.skip_final_snapshot
   storage_encrypted          = aws_db_instance.this.storage_encrypted
   storage_type               = aws_db_instance.this.storage_type
   vpc_security_group_ids     = aws_db_instance.this.vpc_security_group_ids

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -50,7 +50,7 @@ resource "aws_db_instance" "replica" {
   auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
-  deletion_protection        = true
+  deletion_protection        = var.enable_replica_deletion_protection
   instance_class             = aws_db_instance.this.instance_class
   maintenance_window         = aws_db_instance.this.maintenance_window
   multi_az                   = aws_db_instance.this.multi_az

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -50,7 +50,7 @@ resource "aws_db_instance" "replica" {
   auto_minor_version_upgrade = aws_db_instance.this.auto_minor_version_upgrade
   copy_tags_to_snapshot      = aws_db_instance.this.copy_tags_to_snapshot
   delete_automated_backups   = aws_db_instance.this.delete_automated_backups
-  deletion_protection        = var.enable_replica_deletion_protection
+  deletion_protection        = var.enable_replica_deletion_protection # needs to be set to false and applied if you need to delete the replica DB
   instance_class             = aws_db_instance.this.instance_class
   maintenance_window         = aws_db_instance.this.maintenance_window
   multi_az                   = aws_db_instance.this.multi_az

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -28,6 +28,11 @@ variable "enable_primary_deletion_protection" {
   description = "Whether the primary database should have deletion protection enabled"
 }
 
+variable "enable_replica_deletion_protection" {
+  type        = bool
+  description = "Whether the replica database should have deletion protection enabled"
+}
+
 variable "ecs_security_group_id" {
   type        = string
   description = "The id of the ecs security group for ecs ingress"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -355,6 +355,7 @@ module "database" {
 
   apply_changes_immediately          = false
   enable_primary_deletion_protection = true
+  enable_replica_deletion_protection = true
   highly_available                   = true
   skip_final_snapshot                = false
   instance_class                     = "db.t3.small"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -193,6 +193,7 @@ module "database" {
 
   apply_changes_immediately          = true
   enable_primary_deletion_protection = true
+  enable_replica_deletion_protection = true
   highly_available                   = false
   skip_final_snapshot                = false
   instance_class                     = "db.t3.small"


### PR DESCRIPTION
- Removed unrequired final snapshot config on the DB replica, as this doesn't / can't create any snapshots and it makes it harder to delete (necessary for the restore procedure)

- Added a final snapshot identifier for Redis. The Redis cluster has to be deleted as part of the restoration procedure, and I thought it would be good to have a final snapshot of it before so

- There are new docs for the backup and restoration procedures here to be reviewed. They aren't polished but the steps outline everything that needs to be done
[DB](https://dluhcdigital.atlassian.net/wiki/spaces/MC/pages/52166897/AWS+DB+Backup+and+Restore+Process)
[Redis](https://dluhcdigital.atlassian.net/wiki/spaces/MC/pages/52232460/AWS+Redis+Backup+and+Restore+Process)