### PR TITLE
CLDC-2610: Update app task cpu and memory, and source s3 buckets for Prod

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -80,8 +80,8 @@ locals {
 module "application" {
   source = "../modules/application"
 
-  app_task_cpu    = 512
-  app_task_memory = 1024
+  app_task_cpu    = 1024
+  app_task_memory = 2048
 
   sidekiq_task_cpu           = 1024
   sidekiq_task_desired_count = 2
@@ -243,12 +243,12 @@ module "s3_migration" {
   prefix = local.prefix
   buckets = {
     export = {
-      source      = "",
+      source      = "s3://paas-s3-broker-prod-lon-b4f97132-daa8-4e37-b675-4a05dad7a9f4",
       destination = "s3://${module.cds_export.details.bucket_name}",
       policy_arn  = module.cds_export.read_write_policy_arn
     },
     csv = {
-      source      = "",
+      source      = "s3://paas-s3-broker-prod-lon-1b5cddc8-08d8-45fa-8246-9a6ad5acdfb9",
       destination = "s3://${module.bulk_upload.details.bucket_name}",
       policy_arn  = module.bulk_upload.read_write_policy_arn
     }


### PR DESCRIPTION
- Bump up the app task CPU and Memory. We noticed the sales-log page was taking ~2/3s to load in AWS, compared to PaaS which took about ~1s). Bumping up these specs made the load times in AWS align with PaaS.

- Pre-filled the source S3 buckets for S3-migration from PaaS prod (we'll check this on migration day to ensure they are correct / the same)