### PR TITLE
Suppress missing data in alarms for review apps

### DIFF
--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -91,6 +91,7 @@ module "application" {
   relative_root                                     = "/${terraform.workspace}"
   sentry_dsn_secret_arn                             = data.terraform_remote_state.development_shared.outputs.application_secrets_sentry_dsn_secret_arn
   sns_topic_arn                                     = data.terraform_remote_state.development_shared.outputs.monitoring_sns_topic_arn
+  suppress_missing_data_in_alarms                   = true
   vpc_id                                            = data.terraform_remote_state.development_shared.outputs.networking_vpc_id
 }
 

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -11,6 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "app_average_cpu" {
   statistic                 = "Average"
   threshold                 = 80
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -31,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "app_max_task_cpu" {
   statistic                 = "Maximum"
   threshold                 = 80
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -51,6 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "app_average_memory" {
   statistic                 = "Average"
   threshold                 = 80
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -71,6 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "app_max_task_memory" {
   statistic                 = "Maximum"
   threshold                 = 80
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -129,6 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_average_cpu" {
   statistic                 = "Average"
   threshold                 = 90
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -149,6 +154,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_max_task_cpu" {
   statistic                 = "Maximum"
   threshold                 = 90
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -169,6 +175,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_average_memory" {
   statistic                 = "Average"
   threshold                 = 90
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -189,6 +196,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_max_task_memory" {
   statistic                 = "Maximum"
   threshold                 = 50
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -247,6 +255,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
   statistic                 = "SampleCount"
   threshold                 = var.sidekiq_task_desired_count
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.this.name
@@ -267,6 +276,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_count" {
   statistic                 = "Minimum"
   threshold                 = var.app_task_desired_count
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix
@@ -287,6 +297,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_count" {
   statistic                 = "Maximum"
   threshold                 = 0
   insufficient_data_actions = []
+  treat_missing_data        = var.suppress_missing_data_in_alarms ? "notBreaching" : "breaching"
 
   dimensions = {
     LoadBalancer = var.load_balancer_arn_suffix

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -165,6 +165,12 @@ variable "sns_topic_arn" {
   description = "The arn of the sns topic"
 }
 
+variable "suppress_missing_data_in_alarms" {
+  type        = bool
+  description = "If true, cpu / memory / host count alarms treat missing data as ok - otherwise they treat it as breaching"
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the VPC to be associated with."


### PR DESCRIPTION
We keep getting emails for these alarms going from insufficient data -> ok shortly after a review app is first set up.

For review apps, this is annoying and there is little risk by potentially ignoring lack of data.
For staging and prod, missing data should not happen because the environments are already set up (data shouldn't be missing during a release, just when the infra setup happens) so is concerning, hence we'll have these metrics alarm for missing data.