### PR TITLE
Improve alarm setup

### DIFF
--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -92,6 +92,7 @@ module "application" {
   sentry_dsn_secret_arn                             = data.terraform_remote_state.development_shared.outputs.application_secrets_sentry_dsn_secret_arn
   sns_topic_arn                                     = data.terraform_remote_state.development_shared.outputs.monitoring_sns_topic_arn
   suppress_missing_data_in_alarms                   = true
+  suppress_ok_notifications                         = true
   vpc_id                                            = data.terraform_remote_state.development_shared.outputs.networking_vpc_id
 }
 

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "app_average_cpu" {
   evaluation_periods        = 5
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Average"
   threshold                 = 80
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "app_max_task_cpu" {
   evaluation_periods        = 30
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Maximum"
   threshold                 = 80
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "app_average_memory" {
   evaluation_periods        = 5
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Average"
   threshold                 = 80
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "app_max_task_memory" {
   evaluation_periods        = 30
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Maximum"
   threshold                 = 80
@@ -90,7 +90,7 @@ resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
   evaluation_periods        = 1
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 8 * 60 # By causing the app to fail repeatedly (with both 2 tasks and 4 tasks running) I found that double the desired count would reliably fail in an 8 minute period.
   statistic                 = "Sum"
   threshold                 = 2 * var.app_task_desired_count
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "app_service_action_problem" {
   evaluation_periods        = 1
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Sum"
   threshold                 = 1
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_average_cpu" {
   evaluation_periods        = 5
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Average"
   threshold                 = 90
@@ -172,7 +172,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_average_memory" {
   evaluation_periods        = 5
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Average"
   threshold                 = 90
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_max_task_memory" {
   evaluation_periods        = 30
   metric_name               = "MemoryUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Maximum"
   threshold                 = 50
@@ -214,7 +214,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_tasks_exited" {
   evaluation_periods        = 1
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 3 * 60 # By causing sidekiq to fail repeatedly (with both 1 tasks and 2 tasks running) I found that double the desired count would reliably fail in a 3 minute period.
   statistic                 = "Sum"
   threshold                 = 2 * var.sidekiq_task_desired_count
@@ -234,7 +234,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_service_action_problem" {
   evaluation_periods        = 1
   metric_name               = "TriggeredRules"
   namespace                 = "AWS/Events"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Sum"
   threshold                 = 1
@@ -254,7 +254,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_running_tasks" {
   evaluation_periods        = 1
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/ECS"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "SampleCount"
   threshold                 = var.sidekiq_task_desired_count
@@ -275,7 +275,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts_count" {
   evaluation_periods        = 1
   metric_name               = "HealthyHostCount"
   namespace                 = "AWS/ApplicationELB"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Minimum"
   threshold                 = var.app_task_desired_count
@@ -296,7 +296,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_hosts_count" {
   evaluation_periods        = 1
   metric_name               = "UnHealthyHostCount"
   namespace                 = "AWS/ApplicationELB"
-  ok_actions                = [var.sns_topic_arn]
+  ok_actions                = var.suppress_ok_notifications ? [] : [var.sns_topic_arn]
   period                    = 60
   statistic                 = "Maximum"
   threshold                 = 0

--- a/terraform/modules/application/alarms.tf
+++ b/terraform/modules/application/alarms.tf
@@ -95,6 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "app_tasks_exited" {
   statistic                 = "Sum"
   threshold                 = 2 * var.app_task_desired_count
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     RuleName = aws_cloudwatch_event_rule.app_task_exited.name
@@ -114,6 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "app_service_action_problem" {
   statistic                 = "Sum"
   threshold                 = 1
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     RuleName = aws_cloudwatch_event_rule.app_service_action_problem.name
@@ -217,6 +219,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_tasks_exited" {
   statistic                 = "Sum"
   threshold                 = 2 * var.sidekiq_task_desired_count
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     RuleName = aws_cloudwatch_event_rule.sidekiq_task_exited.name
@@ -236,6 +239,7 @@ resource "aws_cloudwatch_metric_alarm" "sidekiq_service_action_problem" {
   statistic                 = "Sum"
   threshold                 = 1
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     RuleName = aws_cloudwatch_event_rule.sidekiq_service_action_problem.name

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -171,6 +171,12 @@ variable "suppress_missing_data_in_alarms" {
   default     = false
 }
 
+variable "suppress_ok_notifications" {
+  type        = bool
+  description = "If true, do not send notifications when alarm states change to OK"
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the VPC to be associated with."


### PR DESCRIPTION
* Makes TriggeredRules alarms always treat missing data as not breaching - we weren't seeing these send a -> OK notification on creation because they never got any data (and only would if something was wrong)
* Suppresses -> OK notifications for review apps, because they happen on infra creation and are not important enough for that env to offset the noise