### PR TITLE
Cldc 3115 reduce dev db spec

### DIFF
--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -133,14 +133,14 @@ module "certificates" {
 module "database" {
   source = "../../modules/rds"
 
-  allocated_storage       = 50
+  allocated_storage       = 35
   backup_retention_period = 0 # no backups
 
   apply_changes_immediately          = true
   enable_primary_deletion_protection = true
   multi_az                           = false
   skip_final_snapshot                = true
-  instance_class                     = "db.m5.xlarge"
+  instance_class                     = "db.t4g.small"
 
   prefix = local.prefix
 

--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -138,8 +138,7 @@ module "database" {
 
   apply_changes_immediately          = true
   enable_primary_deletion_protection = true
-  enable_replica_deletion_protection = true
-  highly_available                   = false
+  multi_az                           = false
   skip_final_snapshot                = true
   instance_class                     = "db.m5.xlarge"
 

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -22,7 +22,7 @@ resource "aws_db_instance" "this" {
   final_snapshot_identifier  = var.prefix
   instance_class             = var.instance_class
   maintenance_window         = "Mon:02:33-Mon:03:03"
-  multi_az                   = true
+  multi_az                   = var.multi_az
   password                   = random_password.this.result
   port                       = var.database_port
   publicly_accessible        = false
@@ -43,7 +43,7 @@ resource "aws_db_instance" "replica" {
   #checkov:skip=CKV_AWS_118:monitoring TODO CLDC-2660
   #checkov:skip=CKV_AWS_353:performance insights TODO CLDC-2660 if necessary
   #checkov:skip=CKV_AWS_354:performance insights TODO CLDC-2660 if insights are necessary
-  count = var.highly_available ? 1 : 0
+  count = var.create_replica ? 1 : 0
 
   identifier                 = "${var.prefix}-replica"
   apply_immediately          = aws_db_instance.this.apply_immediately

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -13,6 +13,12 @@ variable "backup_retention_period" {
   description = "The number of days to retain db backups for. If 0 then the database will not be backed up"
 }
 
+variable "create_replica" {
+  type        = bool
+  description = "If true, creates a replica db"
+  default     = false
+}
+
 variable "database_port" {
   type        = number
   description = "The network port the database runs on"
@@ -30,7 +36,8 @@ variable "enable_primary_deletion_protection" {
 
 variable "enable_replica_deletion_protection" {
   type        = bool
-  description = "Whether the replica database should have deletion protection enabled"
+  description = "Whether the replica database (if create_replica is true) should have deletion protection enabled"
+  default     = true
 }
 
 variable "ecs_security_group_id" {
@@ -43,14 +50,14 @@ variable "ecs_task_execution_role_arn" {
   description = "The arn of the app task execution role"
 }
 
-variable "highly_available" {
-  type        = bool
-  description = "Whether or not to make the db highly available (whether to have replicas or not)."
-}
-
 variable "instance_class" {
   type        = string
   description = "The instance class of the DB."
+}
+
+variable "multi_az" {
+  type        = bool
+  description = "Whether the database should be multi-az"
 }
 
 variable "prefix" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -193,9 +193,10 @@ module "database" {
   backup_retention_period = 7
 
   apply_changes_immediately          = false
+  create_replica                     = true
   enable_primary_deletion_protection = true
   enable_replica_deletion_protection = true
-  highly_available                   = true
+  multi_az                           = true
   skip_final_snapshot                = false
   instance_class                     = "db.t3.small"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -193,8 +193,7 @@ module "database" {
 
   apply_changes_immediately          = true
   enable_primary_deletion_protection = true
-  enable_replica_deletion_protection = true
-  highly_available                   = false
+  multi_az                           = true
   skip_final_snapshot                = false
   instance_class                     = "db.t3.small"
 


### PR DESCRIPTION
This looks like it will meet our actual usage needs very comfortably - it does assume we are not using too many review apps heavily at once, which feels like a safe assumption.

We may even be able to get away with micro instead of small, but the savings there are much smaller scale so it feels best to start with this.