### PR TITLE
CLDC-3115: Restore dev db allocated storage amount as AWS won't allow reduction

### DIFF
--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -133,7 +133,7 @@ module "certificates" {
 module "database" {
   source = "../../modules/rds"
 
-  allocated_storage       = 35
+  allocated_storage       = 50
   backup_retention_period = 0 # no backups
 
   apply_changes_immediately          = true


### PR DESCRIPTION
AWS won't allow you to reduce storage amounts in place, and it doesn't seem worth the effort of recreating the db right now.