### PR TITLE
Update alert descriptions and add rds_cpu_anomaly alert

### DIFF
--- a/terraform/modules/rds/alarms.tf
+++ b/terraform/modules/rds/alarms.tf
@@ -16,6 +16,16 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.this.identifier
   }
+
+  alarm_description = <<EOF
+  High CPU utilization detected on RDS instance ${aws_db_instance.this.identifier}.
+  Possible causes include slow-running queries or high concurrent connections.
+
+  1. Check top SQL queries in RDS Performance Insights: [Performance Insights Dashboard](https://console.aws.amazon.com/rds/home?region=eu-west-2#performance-insights-v20206:/resourceId/${aws_db_instance.this.identifier})
+  2. Investigate recent application changes or deployments.
+  3. Review the CloudWatch dashboard for more metrics: [CloudWatch Dashboard](https://console.aws.amazon.com/cloudwatch/home?region=eu-west-2#dashboards)
+
+  EOF
 }
 
 resource "aws_cloudwatch_metric_alarm" "rds_storage" {
@@ -35,5 +45,48 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
 
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.this.identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_anomaly" {
+  alarm_name                = "${var.prefix}-rds-cpu-anomaly"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  evaluation_periods        = 5
+  threshold_metric_id       = "e1"
+  insufficient_data_actions = []
+  alarm_actions             = [var.sns_topic_arn]
+  ok_actions                = [var.sns_topic_arn]
+  alarm_description         = <<EOF
+  Anomaly detected in CPU utilization on RDS instance ${aws_db_instance.this.identifier}.
+  This may indicate issues such as inefficient queries, unexpected traffic spikes, or resource contention.
+
+  Recommended Actions:
+  1. Check top SQL queries in RDS Performance Insights: [Performance Insights Dashboard](https://console.aws.amazon.com/rds/home?region=eu-west-2#performance-insights-v20206:/resourceId/${aws_db_instance.this.identifier})
+  2. Investigate recent application changes or deployments that might be impacting performance.
+  3. Review the CloudWatch dashboard for additional metrics and trends: [CloudWatch Dashboard](https://console.aws.amazon.com/cloudwatch/home?region=eu-west-2#dashboards)
+  
+  EOF
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1)"
+    label       = "CPUUtilization (Expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id          = "m1"
+    return_data = "true"
+    metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/EC2"
+      period      = 120
+      stat        = "Average"
+      unit        = "Count"
+
+      dimensions = {
+        DBInstanceIdentifier = aws_db_instance.this.identifier
+      }
+    }
   }
 }


### PR DESCRIPTION
- Keep existing CPU alerts as a proxy for slow queries (slow query metrics are not exported to CloudWatch). Updated alert descriptions to include links to RDS Performance Insights for more actionable insights. Considered creating a lambda for custom metrics but it feels like more effort than necessary.
- Add an anomaly detection alarm for RDS CPU. This should be more adaptive and may catch performance issues earlier than static thresholds.

Hoping with the alert descriptions these might feel a bit more actionable. Default email format for alerts still feels like JSON vomit tho.