### PR TITLE
CLDC-3616: Attach new certificates to cloudfront and load balancer

### DIFF
--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -206,18 +206,19 @@ module "front_door" {
 
   restrict_by_geolocation = true
 
-  prefix                        = local.prefix
-  alarm_topic_arn               = module.monitoring_topic_us_east_1.sns_topic_arn
-  append_suffix_to_bucket_names = ["load-balancer-logs"]
-  application_port              = local.application_port
-  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name        = local.app_host
-  ecs_security_group_id         = module.application_security_group.ecs_security_group_id
-  enable_aws_shield             = local.enable_aws_shield
-  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  load_balancer_domain_name     = local.load_balancer_domain_name
-  public_subnet_ids             = module.networking.public_subnet_ids
-  vpc_id                        = module.networking.vpc_id
+  prefix                                   = local.prefix
+  alarm_topic_arn                          = module.monitoring_topic_us_east_1.sns_topic_arn
+  append_suffix_to_bucket_names            = ["load-balancer-logs"]
+  application_port                         = local.application_port
+  cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
+  cloudfront_domain_name                   = local.app_host
+  ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
+  enable_aws_shield                        = local.enable_aws_shield
+  load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn
+  load_balancer_additional_certificate_arn = module.certs_for_new_domain.load_balancer_certificate_arn
+  load_balancer_domain_name                = local.load_balancer_domain_name
+  public_subnet_ids                        = module.networking.public_subnet_ids
+  vpc_id                                   = module.networking.vpc_id
 
   initial_create = var.initial_create
 }

--- a/terraform/development/shared/main.tf
+++ b/terraform/development/shared/main.tf
@@ -212,6 +212,7 @@ module "front_door" {
   application_port                         = local.application_port
   cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
   cloudfront_domain_name                   = local.app_host
+  cloudfront_additional_domain_name        = local.new_app_host
   ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
   enable_aws_shield                        = local.enable_aws_shield
   load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn

--- a/terraform/modules/front_door/cloudfront.tf
+++ b/terraform/modules/front_door/cloudfront.tf
@@ -12,7 +12,7 @@ resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV_AWS_86:TODO we will be implementing logging later
   #checkov:skip=CKV_AWS_305:no need to define a default root object because the root of our distribution is just the app's homepage
   #checkov:skip=CKV_AWS_310:we have decided that we're unlikely to need a secondary load balancer
-  aliases         = var.initial_create ? [] : [var.cloudfront_domain_name]
+  aliases         = var.initial_create ? [] : [var.cloudfront_domain_name, var.cloudfront_additional_domain_name]
   enabled         = true
   http_version    = "http2and3"
   is_ipv6_enabled = true

--- a/terraform/modules/front_door/load_balancer.tf
+++ b/terraform/modules/front_door/load_balancer.tf
@@ -38,3 +38,10 @@ resource "aws_lb_listener" "https" {
     order = 50000 # this is the highest value possible so will be performed last out of all listener rules
   }
 }
+
+resource "aws_lb_listener_certificate" "additional_cert" {
+  count = var.initial_create ? 0 : 1
+
+  listener_arn    = aws_lb_listener.https[0].arn
+  certificate_arn = var.load_balancer_additional_certificate_arn
+}

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -25,6 +25,11 @@ variable "cloudfront_domain_name" {
   description = "The domain name of the cloudfront distribution"
 }
 
+variable "cloudfront_additional_domain_name" {
+  type        = string
+  description = "Additional domain name for cloudfront distribution"
+}
+
 variable "ecs_security_group_id" {
   type        = string
   description = "The id of the ecs security group for ecs egress"

--- a/terraform/modules/front_door/variables.tf
+++ b/terraform/modules/front_door/variables.tf
@@ -45,6 +45,11 @@ variable "load_balancer_certificate_arn" {
   description = "The arn of the certifcate to be associated with the load balancer HTTPS listener"
 }
 
+variable "load_balancer_additional_certificate_arn" {
+  type        = string
+  description = "Arn of additional certificate to be associated with the load balancer"
+}
+
 variable "load_balancer_domain_name" {
   type        = string
   description = "Then domain name of the load balancer"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -307,17 +307,18 @@ module "front_door" {
 
   restrict_by_geolocation = false
 
-  prefix                        = local.prefix
-  alarm_topic_arn               = module.monitoring_topic_us_east_1.sns_topic_arn
-  application_port              = local.application_port
-  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name        = local.app_host
-  ecs_security_group_id         = module.application_security_group.ecs_security_group_id
-  enable_aws_shield             = local.enable_aws_shield
-  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  load_balancer_domain_name     = local.load_balancer_domain_name
-  public_subnet_ids             = module.networking.public_subnet_ids
-  vpc_id                        = module.networking.vpc_id
+  prefix                                   = local.prefix
+  alarm_topic_arn                          = module.monitoring_topic_us_east_1.sns_topic_arn
+  application_port                         = local.application_port
+  cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
+  cloudfront_domain_name                   = local.app_host
+  ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
+  enable_aws_shield                        = local.enable_aws_shield
+  load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn
+  load_balancer_additional_certificate_arn = module.certs_for_new_domain.load_balancer_certificate_arn
+  load_balancer_domain_name                = local.load_balancer_domain_name
+  public_subnet_ids                        = module.networking.public_subnet_ids
+  vpc_id                                   = module.networking.vpc_id
 
   initial_create = var.initial_create
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -312,6 +312,7 @@ module "front_door" {
   application_port                         = local.application_port
   cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
   cloudfront_domain_name                   = local.app_host
+  cloudfront_additional_domain_name        = local.new_app_host
   ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
   enable_aws_shield                        = local.enable_aws_shield
   load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -305,17 +305,18 @@ module "front_door" {
 
   restrict_by_geolocation = true
 
-  prefix                        = local.prefix
-  alarm_topic_arn               = module.monitoring_topic_us_east_1.sns_topic_arn
-  application_port              = local.application_port
-  cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
-  cloudfront_domain_name        = local.app_host
-  ecs_security_group_id         = module.application_security_group.ecs_security_group_id
-  enable_aws_shield             = local.enable_aws_shield
-  load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
-  load_balancer_domain_name     = local.load_balancer_domain_name
-  public_subnet_ids             = module.networking.public_subnet_ids
-  vpc_id                        = module.networking.vpc_id
+  prefix                                   = local.prefix
+  alarm_topic_arn                          = module.monitoring_topic_us_east_1.sns_topic_arn
+  application_port                         = local.application_port
+  cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
+  cloudfront_domain_name                   = local.app_host
+  ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
+  enable_aws_shield                        = local.enable_aws_shield
+  load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn
+  load_balancer_additional_certificate_arn = module.certs_for_new_domain.load_balancer_certificate_arn
+  load_balancer_domain_name                = local.load_balancer_domain_name
+  public_subnet_ids                        = module.networking.public_subnet_ids
+  vpc_id                                   = module.networking.vpc_id
 
   initial_create = var.initial_create
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -310,6 +310,7 @@ module "front_door" {
   application_port                         = local.application_port
   cloudfront_certificate_arn               = module.certs_for_new_domain.cloudfront_certificate_arn
   cloudfront_domain_name                   = local.app_host
+  cloudfront_additional_domain_name        = local.new_app_host
   ecs_security_group_id                    = module.application_security_group.ecs_security_group_id
   enable_aws_shield                        = local.enable_aws_shield
   load_balancer_certificate_arn            = module.certificates.load_balancer_certificate_arn


### PR DESCRIPTION
This (combined with the DNS changes) allows the site to be reached via either the old or new url