### PR TITLE
CLDC-4030: Add separate limits for ad hoc CPU & memory

### DIFF
--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -63,6 +63,9 @@ module "application" {
   sidekiq_task_desired_count = 1
   sidekiq_task_memory        = 1024
 
+  ad_hoc_task_cpu = 512
+  ad_hoc_task_memory = 4096
+
   out_of_hours_scale_down = {
     enabled = true
     timings = {

--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -63,7 +63,7 @@ module "application" {
   sidekiq_task_desired_count = 1
   sidekiq_task_memory        = 1024
 
-  ad_hoc_task_cpu = 512
+  ad_hoc_task_cpu    = 512
   ad_hoc_task_memory = 4096
 
   out_of_hours_scale_down = {

--- a/terraform/modules/application/ecs.tf
+++ b/terraform/modules/application/ecs.tf
@@ -171,9 +171,9 @@ resource "aws_ecs_task_definition" "sidekiq" {
 resource "aws_ecs_task_definition" "ad_hoc_tasks" {
   #checkov:skip=CKV_AWS_336:using readonlyRootFilesystem to true breaks the app, as it needs to write to app/tmp/pids for example
   family                   = "${var.prefix}-ad-hoc"
-  cpu                      = var.app_task_cpu
+  cpu                      = var.ad_hoc_task_cpu
   execution_role_arn       = var.ecs_task_execution_role_arn
-  memory                   = var.app_task_memory #MiB
+  memory                   = var.ad_hoc_task_memory #MiB
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = var.ecs_task_role_arn

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -15,7 +15,7 @@ variable "app_task_desired_count" {
 
 variable "app_task_memory" {
   type        = number
-  description = "The amount of memory used by the ecs app task"
+  description = "The amount of memory (in MiB) used by the ecs app task"
 }
 
 variable "application_port" {
@@ -199,7 +199,7 @@ variable "sidekiq_task_desired_count" {
 
 variable "sidekiq_task_memory" {
   type        = number
-  description = "The amount of memory used by the ecs sidekiq task"
+  description = "The amount of memory (in MiB) used by the ecs sidekiq task"
 }
 
 variable "ad_hoc_task_cpu" {
@@ -209,7 +209,7 @@ variable "ad_hoc_task_cpu" {
 
 variable "ad_hoc_task_memory" {
   type        = number
-  description = "The maximum amount of memory that can be used by the ad hoc task runner"
+  description = "The maximum amount of memory (in MiB) that can be used by the ad hoc task runner"
 }
 
 variable "sns_topic_arn" {

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -202,6 +202,16 @@ variable "sidekiq_task_memory" {
   description = "The amount of memory used by the ecs sidekiq task"
 }
 
+variable "ad_hoc_task_cpu" {
+  type        = number
+  description = "The maximum amount of cpu units that can be used by the ad hoc task runner"
+}
+
+variable "ad_hoc_task_memory" {
+  type        = number
+  description = "The maximum amount of memory that can be used by the ad hoc task runner"
+}
+
 variable "sns_topic_arn" {
   type        = string
   description = "The arn of the sns topic"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -96,7 +96,7 @@ module "application" {
   sidekiq_task_desired_count = 2
   sidekiq_task_memory        = 8192
 
-  ad_hoc_task_cpu = 1024
+  ad_hoc_task_cpu    = 1024
   ad_hoc_task_memory = 8192
 
   out_of_hours_scale_down = {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -96,6 +96,9 @@ module "application" {
   sidekiq_task_desired_count = 2
   sidekiq_task_memory        = 8192
 
+  ad_hoc_task_cpu = 1024
+  ad_hoc_task_memory = 8192
+
   out_of_hours_scale_down = {
     enabled = true
     timings = {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -96,6 +96,9 @@ module "application" {
   sidekiq_task_desired_count = 2
   sidekiq_task_memory        = 8192
 
+  ad_hoc_task_cpu = 512
+  ad_hoc_task_memory = 4096
+
   out_of_hours_scale_down = {
     enabled = true
     timings = {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -96,7 +96,7 @@ module "application" {
   sidekiq_task_desired_count = 2
   sidekiq_task_memory        = 8192
 
-  ad_hoc_task_cpu = 512
+  ad_hoc_task_cpu    = 512
   ad_hoc_task_memory = 4096
 
   out_of_hours_scale_down = {


### PR DESCRIPTION
this lets us use the maximum amount of our memory requirement, and increase cpu in the future if needed

I'll suggest in documentation by default to use less than this, but setting the max to this allows us to create a task up to this size if required