### PR TITLE
CLDC-4337: Revert CLDC-4335: "Extend review apps from 7pm to 9pm"

### DIFF
--- a/terraform/development/per_review_app/main.tf
+++ b/terraform/development/per_review_app/main.tf
@@ -97,7 +97,7 @@ module "application" {
     enabled = true
     timings = {
       workday_start = "0 8"
-      workday_end   = "0 21"
+      workday_end   = "0 19"
     }
     scale_to = {
       app     = 0


### PR DESCRIPTION
Reverts communitiesuk/submit-social-housing-lettings-and-sales-data-infrastructure#173

closes [CLDC-4337](https://mhclgdigital.atlassian.net/browse/CLDC-4337)